### PR TITLE
feat: PDF export toggles for QR code and clock times

### DIFF
--- a/backend/pgnExport/pdf/TypstGenerator.ts
+++ b/backend/pgnExport/pdf/TypstGenerator.ts
@@ -275,10 +275,15 @@ export class TypstGenerator {
                 .filter((n) => n) ?? [];
         const nagLabel = this.options.skipNags ? '' : nagDetails.map((n) => n.label).join('');
 
+        const clockLabel =
+            !this.options.skipClocks && move.commentDiag?.clk
+                ? ` #text(size: 0.8em, fill: gray)[${escape(move.commentDiag.clk)}]`
+                : '';
+
         if (!depth) {
-            this.result += `*${moveTex}${nagLabel}*`;
+            this.result += `*${moveTex}${nagLabel}*${clockLabel}`;
         } else {
-            this.result += `${moveTex}${nagLabel}`;
+            this.result += `${moveTex}${nagLabel}${clockLabel}`;
         }
 
         if (move.next || move.commentAfter) {

--- a/backend/pgnExport/pdf/pdf.ts
+++ b/backend/pgnExport/pdf/pdf.ts
@@ -14,7 +14,9 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
         const request = parseBody(event, PdfExportSchema);
         const generator = new TypstGenerator({
             ...request,
-            qrcodeFilename: `/tmp/${event.requestContext.requestId}-qrcode.png`,
+            qrcodeFilename: request.skipQrCode
+                ? undefined
+                : `/tmp/${event.requestContext.requestId}-qrcode.png`,
         });
         fs.writeFileSync(`/tmp/${event.requestContext.requestId}.typ`, await generator.toTypst());
         console.log('Generated typ file');

--- a/common/src/pgn/export.ts
+++ b/common/src/pgn/export.ts
@@ -32,6 +32,12 @@ export const PdfExportSchema = z.object({
     /** Whether to skip rendering null moves. */
     skipNullMoves: z.boolean().optional(),
 
+    /** Whether to skip rendering clock times. */
+    skipClocks: z.boolean().optional(),
+
+    /** Whether to skip rendering the QR code in the PDF. */
+    skipQrCode: z.boolean().optional(),
+
     /** The number of ply between diagrams. */
     plyBetweenDiagrams: z.number().int().min(-1).max(40),
 });

--- a/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
@@ -263,7 +263,6 @@ export function ShareTab() {
                 chess?.renderPgn({
                     skipComments,
                     skipNags,
-                    skipDrawables,
                     skipVariations,
                     skipNullMoves,
                     skipHeader,

--- a/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
@@ -72,6 +72,8 @@ export function ShareTab() {
         setSkipHeader,
         skipClocks,
         setSkipClocks,
+        skipQrCode,
+        setSkipQrCode,
         pdfDiagramMode,
         setPdfDiagramMode,
         plyBetweenDiagrams,
@@ -257,7 +259,15 @@ export function ShareTab() {
 
         try {
             pdfRequest.onStart();
-            const pgn = chess.renderPgn();
+            const pgn =
+                chess?.renderPgn({
+                    skipComments,
+                    skipNags,
+                    skipDrawables,
+                    skipVariations,
+                    skipNullMoves,
+                    skipHeader,
+                }) || '';
 
             const response = await getPdf({
                 pgn,
@@ -267,8 +277,11 @@ export function ShareTab() {
                 skipHeader,
                 skipComments,
                 skipNags,
+                skipDrawables,
                 skipVariations,
                 skipNullMoves,
+                skipClocks,
+                skipQrCode,
                 plyBetweenDiagrams: pdfDiagramMode === 'markedPositions' ? -1 : plyBetweenDiagrams,
             });
 
@@ -441,7 +454,16 @@ export function ShareTab() {
                 </Stack>
 
                 <FormControl sx={{ mt: 1.5, mb: 1 }}>
-                    <FormLabel>PDF Diagrams</FormLabel>
+                    <FormLabel>PDF Options</FormLabel>
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={!skipQrCode}
+                                onChange={(e) => setSkipQrCode(!e.target.checked)}
+                            />
+                        }
+                        label='QR Code'
+                    />
                     <RadioGroup
                         row
                         value={pdfDiagramMode}

--- a/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
@@ -36,6 +36,7 @@ import {
     RadioGroup,
     Slider,
     Stack,
+    Typography,
 } from '@mui/material';
 import copy from 'copy-to-clipboard';
 import { ReactNode, useState } from 'react';
@@ -452,8 +453,11 @@ export function ShareTab() {
                     </FormGroup>
                 </Stack>
 
-                <FormControl sx={{ mt: 1.5, mb: 1 }}>
-                    <FormLabel>PDF Options</FormLabel>
+                <FormGroup sx={{ mt: 2.5, mb: 1 }}>
+                    <Typography variant='h6' color='textSecondary'>
+                        PDF Options
+                    </Typography>
+
                     <FormControlLabel
                         control={
                             <Checkbox
@@ -461,27 +465,32 @@ export function ShareTab() {
                                 onChange={(e) => setSkipQrCode(!e.target.checked)}
                             />
                         }
-                        label='QR Code'
+                        label='Include QR Code to Game'
                     />
-                    <RadioGroup
-                        row
-                        value={pdfDiagramMode}
-                        onChange={(e) =>
-                            setPdfDiagramMode(e.target.value as 'markedPositions' | 'numMoves')
-                        }
-                    >
-                        <FormControlLabel
-                            value='markedPositions'
-                            control={<Radio />}
-                            label='Marked Positions Only'
-                        />
-                        <FormControlLabel
-                            value='numMoves'
-                            control={<Radio />}
-                            label={`Marked Positions + Every ${plyBetweenDiagrams / 2} Moves`}
-                        />
-                    </RadioGroup>
-                </FormControl>
+
+                    <FormControl sx={{ mt: 1.5, mb: 1 }}>
+                        <FormLabel>Diagrams</FormLabel>
+
+                        <RadioGroup
+                            row
+                            value={pdfDiagramMode}
+                            onChange={(e) =>
+                                setPdfDiagramMode(e.target.value as 'markedPositions' | 'numMoves')
+                            }
+                        >
+                            <FormControlLabel
+                                value='markedPositions'
+                                control={<Radio />}
+                                label='Marked Positions Only'
+                            />
+                            <FormControlLabel
+                                value='numMoves'
+                                control={<Radio />}
+                                label={`Marked Positions + Every ${plyBetweenDiagrams / 2} Moves`}
+                            />
+                        </RadioGroup>
+                    </FormControl>
+                </FormGroup>
 
                 {pdfDiagramMode === 'numMoves' && (
                     <FormGroup>

--- a/frontend/src/hooks/usePgnExportOptions.ts
+++ b/frontend/src/hooks/usePgnExportOptions.ts
@@ -29,6 +29,10 @@ export const pgnExportOptions = {
         key: 'export-pgn/skip-clocks',
         default: false,
     },
+    skipQrCode: {
+        key: 'export-pgn/skip-qr-code',
+        default: false,
+    },
     pdfDiagramMode: {
         key: 'export-pgn/pdf-diagram-mode',
         default: 'markedPositions',
@@ -73,6 +77,10 @@ export function usePgnExportOptions() {
         pgnExportOptions.skipClocks.key,
         pgnExportOptions.skipClocks.default,
     );
+    const [skipQrCode, setSkipQrCode] = useLocalStorage<boolean>(
+        pgnExportOptions.skipQrCode.key,
+        pgnExportOptions.skipQrCode.default,
+    );
     const [pdfDiagramMode, setPdfDiagramMode] = useLocalStorage<'markedPositions' | 'numMoves'>(
         pgnExportOptions.pdfDiagramMode.key,
         pgnExportOptions.pdfDiagramMode.default,
@@ -97,6 +105,8 @@ export function usePgnExportOptions() {
         setSkipHeader,
         skipClocks,
         setSkipClocks,
+        skipQrCode,
+        setSkipQrCode,
         pdfDiagramMode,
         setPdfDiagramMode,
         plyBetweenDiagrams,


### PR DESCRIPTION
## Summary

Closes #1482, closes #1483

**QR Code toggle (#1482):** Added `skipQrCode` field to `PdfExportSchema` and a "QR Code" checkbox under the renamed "PDF Options" section. Backend conditionally generates QR code based on this flag. Defaults to on (matches current behavior).

**Clock Times fix (#1483):** The "Clock Times" checkbox existed but had no effect on PDF output. Fixed `onDownloadPdf` to pass export options to the PGN renderer and the backend. Clock times now render as smaller gray text after each move in the PDF via `TypstGenerator`.

**Small fix:** Content checkboxes (Comments, Variations, Glyphs, Null Moves) now correctly affect PDF export too. Previously they only affected PGN copy/download. Added `skipDrawables` and `skipClocks` to the API call so the backend can handle them independently.

**Security:** Clock values are escaped via the existing `escape()` function before Typst output to prevent injection from malformed PGN data.

## Files changed

| File | Change |
|------|--------|
| `common/src/pgn/export.ts` | Added `skipClocks`, `skipQrCode` to `PdfExportSchema` |
| `frontend/src/hooks/usePgnExportOptions.ts` | Added `skipQrCode` localStorage state |
| `frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx` | Fixed PDF render call, added missing fields to API call, QR Code checkbox, renamed section |
| `backend/pgnExport/pdf/pdf.ts` | Conditionally generate QR code file |
| `backend/pgnExport/pdf/TypstGenerator.ts` | Render clock times as gray text after moves |

## Notes for reviewer

- `skipClocks` and `skipDrawables` are intentionally omitted from the `renderPgn()` call in `onDownloadPdf`. The backend needs clock and drawable data in the PGN to render them on diagrams, so the backend's `TypstGenerator` handles these flags independently.
- Pre-existing: `skipHeader` is sent to the PDF backend but `TypstGenerator.makeTitle()` always renders the title regardless. Easy fix if desired, can do in a follow-up.
- Pre-existing: `common/src/pgn/export.ts` only contains `PdfExportSchema`. Could be renamed to `pdfExport.ts` for clarity.
- All existing fields in `PdfExportSchema` use `z.boolean().optional()` which relies on JS truthiness for defaults. Using `.default(false)` would be more explicit. Worth discussing as a codebase-wide improvement.
- No test infrastructure exists for backend TypeScript handlers. The `TypstGenerator` would benefit from a test suite. Happy to set that up as a separate effort.

## Test plan

- [x] "PDF Diagrams" renamed to "PDF Options"
- [x] QR Code checkbox appears, checked by default
- [x] `skipQrCode` toggles correctly in request payload (verified in DevTools Network tab)
- [x] `skipClocks` toggles correctly in request payload
- [x] All other skip fields present in PDF request
- [x] PGN copy/download still respects all checkboxes
- [x] QR Code unchecked: PDF has no QR code (requires backend deploy)
- [x] QR Code checked: PDF has QR code (requires backend deploy)
- [x] Clock Times unchecked: no clocks in PDF (requires backend deploy)
- [x] Clock Times checked: clocks show in gray after moves (requires backend deploy)