### PR TITLE
fix(#2012): pass existing workGoalHistory to settings editor

### DIFF
--- a/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
@@ -96,6 +96,7 @@ export function DailyTrainingPlan() {
                     disabled={!isCurrentUser}
                     initialWeekStart={user.weekStart}
                     workGoal={user.workGoal}
+                    workGoalHistory={user.workGoalHistory}
                 />
             </Stack>
 

--- a/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
@@ -82,6 +82,7 @@ export function WeeklyTrainingPlan() {
                     disabled={!isCurrentUser}
                     initialWeekStart={user.weekStart}
                     workGoal={user.workGoal}
+                    workGoalHistory={user.workGoalHistory}
                 />
             </Stack>
 


### PR DESCRIPTION
## Summary
- Both `WeeklyTrainingPlan` and `DailyTrainingPlan` were rendering `WorkGoalSettingsEditor` without the user's existing `workGoalHistory`
- This caused every save to replace the full history with a single entry instead of being appended to
- Fix: pass `workGoalHistory={user.workGoalHistory}` in both components

## Test plan
- [x] Verified via API responses that `workGoalHistory` appends new entries on save instead of being replaced