### PR TITLE
feat: Add frontend UI and API client for blog comment reactions

### DIFF
--- a/backend/blogService/createComment.ts
+++ b/backend/blogService/createComment.ts
@@ -5,9 +5,9 @@ import { unmarshall } from '@aws-sdk/util-dynamodb';
 import {
     Blog,
     BlogStatuses,
+    Comment,
     createBlogCommentRequestSchema,
 } from '@jackstenglein/chess-dojo-common/src/blog/api';
-import { Comment } from '@jackstenglein/chess-dojo-common/src/database/timeline';
 import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
 import { v4 as uuid } from 'uuid';
 import {
@@ -79,6 +79,7 @@ export const handler: APIGatewayProxyHandlerV2 = async (event) => {
             content: request.content,
             createdAt: now,
             updatedAt: now,
+            reactions: {},
             ...(resolvedParentId && { parentId: resolvedParentId }),
         };
 

--- a/backend/blogService/database.ts
+++ b/backend/blogService/database.ts
@@ -8,7 +8,9 @@ export {
     UpdateItemBuilder,
     and,
     attributeExists,
+    attributeNotExists,
     dynamo,
     equal,
     getUser,
+    or,
 } from '../directoryService/database';

--- a/backend/blogService/serverless.yml
+++ b/backend/blogService/serverless.yml
@@ -152,6 +152,26 @@ functions:
           - dynamodb:GetItem
         Resource: ${param:UsersTableArn}
 
+  updateCommentReaction:
+    handler: updateCommentReaction.handler
+    events:
+      - httpApi:
+          path: /blog/comment-reactions/{owner}/{id+}
+          method: put
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
+    iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:UpdateItem
+        Resource: !GetAtt BlogsTable.Arn
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+        Resource: ${param:UsersTableArn}
+
   update:
     handler: update.handler
     environment:

--- a/backend/blogService/updateCommentReaction.test.ts
+++ b/backend/blogService/updateCommentReaction.test.ts
@@ -1,0 +1,272 @@
+'use strict';
+
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import { marshall } from '@aws-sdk/util-dynamodb';
+import { APIGatewayProxyEventV2, APIGatewayProxyStructuredResultV2 } from 'aws-lambda';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getBlogMock = vi.hoisted(() => vi.fn());
+const getUserMock = vi.hoisted(() => vi.fn());
+const sendMock = vi.hoisted(() => vi.fn());
+const updateOps = vi.hoisted(() => ({
+    sets: [] as Array<{ path: unknown; value: unknown }>,
+    removes: [] as unknown[],
+    condition: undefined as unknown,
+}));
+
+vi.mock('./database', () => {
+    class UpdateItemBuilder {
+        key() {
+            return this;
+        }
+        set(path: unknown, value: unknown) {
+            updateOps.sets.push({ path, value });
+            return this;
+        }
+        remove(path: unknown) {
+            updateOps.removes.push(path);
+            return this;
+        }
+        condition(value: unknown) {
+            updateOps.condition = value;
+            return this;
+        }
+        table() {
+            return this;
+        }
+        return() {
+            return this;
+        }
+        build() {
+            return { input: 'update-comment-reaction' };
+        }
+    }
+
+    return {
+        blogTable: 'test-blogs',
+        dynamo: { send: sendMock },
+        getUser: getUserMock,
+        UpdateItemBuilder,
+        attributeExists: (path: unknown) => ({ type: 'exists', path }),
+        attributeNotExists: (path: unknown) => ({ type: 'not-exists', path }),
+        equal: (path: unknown, value: unknown) => ({ type: 'equal', path, value }),
+        and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
+        or: (...conditions: unknown[]) => ({ type: 'or', conditions }),
+    };
+});
+
+vi.mock('./get', () => ({
+    getBlog: getBlogMock,
+}));
+
+import { handler } from './updateCommentReaction';
+
+function makeEvent(body: Record<string, unknown>, username = 'testuser'): APIGatewayProxyEventV2 {
+    return {
+        body: JSON.stringify(body),
+        pathParameters: { owner: 'chessdojo', id: 'post-1' },
+        requestContext: username
+            ? {
+                  authorizer: {
+                      jwt: {
+                          claims: {
+                              'cognito:username': username,
+                          },
+                      },
+                  },
+              }
+            : {},
+    } as unknown as APIGatewayProxyEventV2;
+}
+
+function makeBlog(comment: Record<string, unknown>, status = 'PUBLISHED') {
+    return {
+        owner: 'chessdojo',
+        id: 'post-1',
+        status,
+        comments: [{ id: 'comment-1', ...comment }],
+    };
+}
+
+function mockSuccessfulUpdate() {
+    sendMock.mockResolvedValue({
+        Attributes: marshall({
+            owner: 'chessdojo',
+            id: 'post-1',
+            status: 'PUBLISHED',
+            comments: [],
+        }),
+    });
+}
+
+async function invoke(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyStructuredResultV2> {
+    return (await handler(event, {} as never, () => {})) as APIGatewayProxyStructuredResultV2;
+}
+
+describe('updateCommentReaction handler', () => {
+    beforeEach(() => {
+        getBlogMock.mockReset();
+        getUserMock.mockReset();
+        sendMock.mockReset();
+        updateOps.sets.length = 0;
+        updateOps.removes.length = 0;
+        updateOps.condition = undefined;
+        getUserMock.mockResolvedValue({
+            displayName: 'Test User',
+            dojoCohort: '1500-1600',
+        });
+    });
+
+    it('returns 400 for an unauthenticated request', async () => {
+        const response = await invoke(
+            makeEvent({ commentId: 'comment-1', reactionType: '👍' }, ''),
+        );
+
+        expect(response.statusCode).toBe(400);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for an unsupported reaction', async () => {
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '🚀' }));
+
+        expect(response.statusCode).toBe(400);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the blog does not exist', async () => {
+        getBlogMock.mockResolvedValue(undefined);
+
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '👍' }));
+
+        expect(response.statusCode).toBe(404);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when the blog is unpublished', async () => {
+        getBlogMock.mockResolvedValue(makeBlog({}, 'DRAFT'));
+
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '👍' }));
+
+        expect(response.statusCode).toBe(403);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the comment does not exist', async () => {
+        getBlogMock.mockResolvedValue({ status: 'PUBLISHED', comments: [] });
+
+        const response = await invoke(
+            makeEvent({ commentId: 'missing-comment', reactionType: '👍' }),
+        );
+
+        expect(response.statusCode).toBe(404);
+        expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it('initializes reactions on a legacy comment', async () => {
+        getBlogMock.mockResolvedValue(makeBlog({}));
+        mockSuccessfulUpdate();
+
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '👍' }));
+
+        expect(response.statusCode).toBe(200);
+        expect(updateOps.sets).toEqual([
+            {
+                path: ['comments', 0, 'reactions'],
+                value: {
+                    testuser: expect.objectContaining({
+                        username: 'testuser',
+                        displayName: 'Test User',
+                        cohort: '1500-1600',
+                        types: ['👍'],
+                    }),
+                },
+            },
+        ]);
+    });
+
+    it('adds a reaction to an initialized reactions map', async () => {
+        getBlogMock.mockResolvedValue(makeBlog({ reactions: {} }));
+        mockSuccessfulUpdate();
+
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '❤️' }));
+
+        expect(response.statusCode).toBe(200);
+        expect(updateOps.sets).toEqual([
+            {
+                path: ['comments', 0, 'reactions', 'testuser'],
+                value: expect.objectContaining({
+                    username: 'testuser',
+                    displayName: 'Test User',
+                    cohort: '1500-1600',
+                    types: ['❤️'],
+                }),
+            },
+        ]);
+    });
+
+    it('replaces the authenticated user reaction with a different reaction', async () => {
+        getBlogMock.mockResolvedValue(
+            makeBlog({
+                reactions: {
+                    testuser: {
+                        username: 'testuser',
+                        displayName: 'Old Name',
+                        cohort: '1400-1500',
+                        updatedAt: '2026-01-01T00:00:00.000Z',
+                        types: ['❤️'],
+                    },
+                },
+            }),
+        );
+        mockSuccessfulUpdate();
+
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '👍' }));
+
+        expect(response.statusCode).toBe(200);
+        expect(updateOps.sets[0]).toEqual({
+            path: ['comments', 0, 'reactions', 'testuser'],
+            value: expect.objectContaining({
+                displayName: 'Test User',
+                cohort: '1500-1600',
+                types: ['👍'],
+            }),
+        });
+    });
+
+    it('removes the authenticated user reaction when toggling the same reaction', async () => {
+        getBlogMock.mockResolvedValue(
+            makeBlog({
+                reactions: {
+                    testuser: {
+                        username: 'testuser',
+                        displayName: 'Test User',
+                        cohort: '1500-1600',
+                        updatedAt: '2026-01-01T00:00:00.000Z',
+                        types: ['🎉'],
+                    },
+                },
+            }),
+        );
+        mockSuccessfulUpdate();
+
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '🎉' }));
+
+        expect(response.statusCode).toBe(200);
+        expect(updateOps.sets).toHaveLength(0);
+        expect(updateOps.removes).toEqual([['comments', 0, 'reactions', 'testuser']]);
+    });
+
+    it('returns 409 when the comment reactions changed concurrently', async () => {
+        getBlogMock.mockResolvedValue(makeBlog({ reactions: {} }));
+        sendMock.mockRejectedValue(
+            new ConditionalCheckFailedException({
+                message: 'Conditional request failed',
+                $metadata: {},
+            }),
+        );
+
+        const response = await invoke(makeEvent({ commentId: 'comment-1', reactionType: '👍' }));
+
+        expect(response.statusCode).toBe(409);
+    });
+});

--- a/backend/blogService/updateCommentReaction.ts
+++ b/backend/blogService/updateCommentReaction.ts
@@ -1,0 +1,135 @@
+'use strict';
+
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+import {
+    Blog,
+    BlogStatuses,
+    updateBlogCommentReactionRequestSchema,
+} from '@jackstenglein/chess-dojo-common/src/blog/api';
+import { APIGatewayProxyHandlerV2 } from 'aws-lambda';
+import {
+    ApiError,
+    errToApiGatewayProxyResultV2,
+    parseEvent,
+    requireUserInfo,
+    success,
+} from '../directoryService/api';
+import {
+    and,
+    attributeExists,
+    attributeNotExists,
+    blogTable,
+    dynamo,
+    equal,
+    getUser,
+    or,
+    UpdateItemBuilder,
+} from './database';
+import { getBlog } from './get';
+
+export const handler: APIGatewayProxyHandlerV2 = async (event) => {
+    try {
+        console.log('Event: %j', event);
+
+        const userInfo = requireUserInfo(event);
+        const request = parseEvent(event, updateBlogCommentReactionRequestSchema);
+        const [user, blog] = await Promise.all([
+            getUser(userInfo.username),
+            getBlog(request.owner, request.id),
+        ]);
+
+        if (!blog) {
+            throw new ApiError({
+                statusCode: 404,
+                publicMessage: `Blog post not found: ${request.owner}/${request.id}`,
+            });
+        }
+        if (blog.status !== BlogStatuses.PUBLISHED) {
+            throw new ApiError({
+                statusCode: 403,
+                publicMessage: 'Reactions are not allowed on unpublished posts',
+            });
+        }
+
+        const commentIndex = (blog.comments ?? []).findIndex(
+            (comment) => comment.id === request.commentId,
+        );
+        if (commentIndex < 0) {
+            throw new ApiError({
+                statusCode: 404,
+                publicMessage: 'Comment not found',
+            });
+        }
+
+        const comment = blog.comments![commentIndex];
+        const reactionsPath = ['comments', commentIndex, 'reactions'];
+        const userReactionPath = [...reactionsPath, userInfo.username];
+        const existingReaction = comment.reactions?.[userInfo.username];
+        const isRemoving = existingReaction?.types?.includes(request.reactionType) ?? false;
+
+        const builder = new UpdateItemBuilder().key('owner', request.owner).key('id', request.id);
+        let reactionCondition = attributeNotExists(userReactionPath);
+
+        if (comment.reactions == null) {
+            const reaction = {
+                username: userInfo.username,
+                displayName: user.displayName,
+                cohort: user.dojoCohort,
+                updatedAt: new Date().toISOString(),
+                types: [request.reactionType],
+            };
+            builder.set(reactionsPath, { [userInfo.username]: reaction });
+            reactionCondition = or(attributeNotExists(reactionsPath), equal(reactionsPath, null));
+        } else if (isRemoving) {
+            builder.remove(userReactionPath);
+            reactionCondition = equal(userReactionPath, existingReaction);
+        } else {
+            const reaction = {
+                username: userInfo.username,
+                displayName: user.displayName,
+                cohort: user.dojoCohort,
+                updatedAt: new Date().toISOString(),
+                types: [request.reactionType],
+            };
+            builder.set(userReactionPath, reaction);
+            if (existingReaction) {
+                reactionCondition = equal(userReactionPath, existingReaction);
+            }
+        }
+
+        const input = builder
+            .condition(
+                and(
+                    attributeExists('id'),
+                    equal(['comments', commentIndex, 'id'], request.commentId),
+                    reactionCondition,
+                ),
+            )
+            .table(blogTable)
+            .return('ALL_NEW')
+            .build();
+
+        const output = await dynamo.send(input);
+        if (!output.Attributes) {
+            throw new ApiError({
+                statusCode: 500,
+                publicMessage: 'Failed to retrieve updated blog post',
+            });
+        }
+
+        return success(unmarshall(output.Attributes) as Blog);
+    } catch (err) {
+        if (err instanceof ConditionalCheckFailedException) {
+            return errToApiGatewayProxyResultV2(
+                new ApiError({
+                    statusCode: 409,
+                    publicMessage:
+                        'Comment reactions were modified by another request. Please try again.',
+                    cause: err,
+                }),
+            );
+        }
+        return errToApiGatewayProxyResultV2(err);
+    }
+};

--- a/common/src/blog/api.ts
+++ b/common/src/blog/api.ts
@@ -2,6 +2,19 @@ import { z } from 'zod';
 
 /** The username of the blog owner for the Chess Dojo blog. */
 export const DOJO_BLOG_OWNER = 'chessdojo';
+/** Verifies the shape of a Reaction on a comment or timeline entry. */
+export const ReactionSchema = z.object({
+    /** The username of the person that reacted. */
+    username: z.string(),
+    /** The display name of the person that reacted. */
+    displayName: z.string(),
+    /** The cohort of the person that reacted. */
+    cohort: z.string(),
+    /** The time the reaction was last changed, in ISO 8601. */
+    updatedAt: z.string(),
+    /** The reaction types set by the user. */
+    types: z.array(z.string()).optional(),
+});
 
 /** Verifies the shape of a Comment on a blog post. */
 export const CommentSchema = z.object({
@@ -23,7 +36,11 @@ export const CommentSchema = z.object({
     content: z.string(),
     /** The id of the root top-level comment this is a reply to. Absent for top-level comments. */
     parentId: z.string().optional(),
+    /** Reactions left by users on the comment, mapped by their usernames. */
+    reactions: z.record(z.string(), ReactionSchema).nullish(),
+    
 });
+
 
 /** A comment on a blog post. */
 export type Comment = z.infer<typeof CommentSchema>;
@@ -182,3 +199,18 @@ export const deleteBlogCommentRequestSchema = z.object({
 
 /** A request to delete a comment on a blog post. */
 export type DeleteBlogCommentRequest = z.infer<typeof deleteBlogCommentRequestSchema>;
+
+/** Verifies the type of a request to update a reaction on a blog comment. */
+export const updateBlogCommentReactionRequestSchema = z.object({
+    /** The username of the blog owner. */
+    owner: z.string().min(1),
+    /** The id of the blog post. */
+    id: z.string().min(1),
+    /** The id of the comment to react to. */
+    commentId: z.string().min(1),
+    /** The type of reaction to toggle */
+    reactionType: z.string().min(1),
+});
+
+/** A request to update a reaction on a blog comment. */
+export type UpdateBlogCommentReactionRequest = z.infer<typeof updateBlogCommentReactionRequestSchema>;

--- a/common/src/blog/api.ts
+++ b/common/src/blog/api.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+/** The allowed reaction types for blog comments. */
+export const BLOG_COMMENT_REACTION_TYPES = ['👍', '❤️', '😂', '🔥', '🎉'] as const;
+export const BlogCommentReactionTypeSchema = z.enum(BLOG_COMMENT_REACTION_TYPES);
+export type BlogCommentReactionType = z.infer<typeof BlogCommentReactionTypeSchema>;
+
 /** The username of the blog owner for the Chess Dojo blog. */
 export const DOJO_BLOG_OWNER = 'chessdojo';
 /** Verifies the shape of a Reaction on a comment or timeline entry. */
@@ -13,8 +18,11 @@ export const ReactionSchema = z.object({
     /** The time the reaction was last changed, in ISO 8601. */
     updatedAt: z.string(),
     /** The reaction types set by the user. */
-    types: z.array(z.string()).optional(),
+    types: z.array(BlogCommentReactionTypeSchema).optional(),
 });
+
+/** A reaction on a blog comment. */
+export type Reaction = z.infer<typeof ReactionSchema>;
 
 /** Verifies the shape of a Comment on a blog post. */
 export const CommentSchema = z.object({
@@ -38,9 +46,7 @@ export const CommentSchema = z.object({
     parentId: z.string().optional(),
     /** Reactions left by users on the comment, mapped by their usernames. */
     reactions: z.record(z.string(), ReactionSchema).nullish(),
-    
 });
-
 
 /** A comment on a blog post. */
 export type Comment = z.infer<typeof CommentSchema>;
@@ -209,8 +215,10 @@ export const updateBlogCommentReactionRequestSchema = z.object({
     /** The id of the comment to react to. */
     commentId: z.string().min(1),
     /** The type of reaction to toggle */
-    reactionType: z.string().min(1),
+    reactionType: BlogCommentReactionTypeSchema,
 });
 
 /** A request to update a reaction on a blog comment. */
-export type UpdateBlogCommentReactionRequest = z.infer<typeof updateBlogCommentReactionRequestSchema>;
+export type UpdateBlogCommentReactionRequest = z.infer<
+    typeof updateBlogCommentReactionRequestSchema
+>;

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -1753,7 +1753,9 @@
         "replyingTo": "Antwort an {name}",
         "writeReply": "Schreib eine Antwort...",
         "postReply": "Antwort posten",
-        "edited": "(bearbeitet)"
+        "edited": "(bearbeitet)",
+        "addReaction": "Reaktion hinzufügen",
+        "reactedByOthers": "{names} und {count} weitere"
     },
     "games": {
         "saveDialog": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -1753,7 +1753,9 @@
         "replyingTo": "Replying to {name}",
         "writeReply": "Write a reply...",
         "postReply": "Post Reply",
-        "edited": "(edited)"
+        "edited": "(edited)",
+        "addReaction": "Add reaction",
+        "reactedByOthers": "{names} and {count} others"
     },
     "games": {
         "saveDialog": {

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -1753,7 +1753,9 @@
         "replyingTo": "Respondiendo a {name}",
         "writeReply": "Escribe una respuesta...",
         "postReply": "Publicar respuesta",
-        "edited": "(editado)"
+        "edited": "(editado)",
+        "addReaction": "Añadir reacción",
+        "reactedByOthers": "{names} y {count} más"
     },
     "games": {
         "saveDialog": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -1753,7 +1753,9 @@
         "replyingTo": "En réponse à {name}",
         "writeReply": "Écris une réponse...",
         "postReply": "Publier la réponse",
-        "edited": "(modifié)"
+        "edited": "(modifié)",
+        "addReaction": "Ajouter une réaction",
+        "reactedByOthers": "{names} et {count} autres"
     },
     "games": {
         "saveDialog": {

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -1753,7 +1753,9 @@
         "replyingTo": "In risposta a {name}",
         "writeReply": "Scrivi una risposta...",
         "postReply": "Pubblica risposta",
-        "edited": "(modificato)"
+        "edited": "(modificato)",
+        "addReaction": "Aggiungi reazione",
+        "reactedByOthers": "{names} e altri {count}"
     },
     "games": {
         "saveDialog": {

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -1753,7 +1753,9 @@
         "replyingTo": "[T] Replying to {name}",
         "writeReply": "[T] Write a reply...",
         "postReply": "[T] Post Reply",
-        "edited": "[T] (edited)"
+        "edited": "[T] (edited)",
+        "addReaction": "[T] Add reaction",
+        "reactedByOthers": "[T] {names} and {count} others"
     },
     "games": {
         "saveDialog": {

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -1753,7 +1753,9 @@
         "replyingTo": "Respondendo a {name}",
         "writeReply": "Escreva uma resposta...",
         "postReply": "Publicar resposta",
-        "edited": "(editado)"
+        "edited": "(editado)",
+        "addReaction": "Adicionar reação",
+        "reactedByOthers": "{names} e mais {count}"
     },
     "games": {
         "saveDialog": {

--- a/frontend/src/api/blogApi.ts
+++ b/frontend/src/api/blogApi.ts
@@ -5,6 +5,7 @@ import {
     DeleteBlogCommentRequest,
     GetBlogRequest,
     ListBlogsRequest,
+    UpdateBlogCommentReactionRequest,
     UpdateBlogCommentRequest,
     UpdateBlogRequest,
 } from '@jackstenglein/chess-dojo-common/src/blog/api';
@@ -121,4 +122,15 @@ export function deleteBlogComment(
         data: { commentId },
         functionName: 'deleteBlogComment',
     });
+}
+
+export function updateBlogCommentReaction(
+    props: Pick<UpdateBlogCommentReactionRequest, 'owner' | 'id' | 'commentId'>,
+    reactionType: string,
+): Promise<AxiosResponse<Blog>> {
+    return axiosService.put<Blog>(
+        `/blog/comments/reactions/${props.owner}/${props.id}`,
+        { commentId: props.commentId, reactionType },
+        { functionName: 'updateBlogCommentReaction' },
+    );
 }

--- a/frontend/src/api/blogApi.ts
+++ b/frontend/src/api/blogApi.ts
@@ -1,5 +1,6 @@
 import {
     Blog,
+    BlogCommentReactionType,
     CreateBlogCommentRequest,
     CreateBlogRequest,
     DeleteBlogCommentRequest,
@@ -126,10 +127,10 @@ export function deleteBlogComment(
 
 export function updateBlogCommentReaction(
     props: Pick<UpdateBlogCommentReactionRequest, 'owner' | 'id' | 'commentId'>,
-    reactionType: string,
+    reactionType: BlogCommentReactionType,
 ): Promise<AxiosResponse<Blog>> {
     return axiosService.put<Blog>(
-        `/blog/comments/reactions/${props.owner}/${props.id}`,
+        `/blog/comment-reactions/${props.owner}/${props.id}`,
         { commentId: props.commentId, reactionType },
         { functionName: 'updateBlogCommentReaction' },
     );

--- a/frontend/src/app/[locale]/(blog)/blog/[...id]/BlogComments.tsx
+++ b/frontend/src/app/[locale]/(blog)/blog/[...id]/BlogComments.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { createBlogComment, deleteBlogComment, updateBlogComment } from '@/api/blogApi';
+import {
+    createBlogComment,
+    deleteBlogComment,
+    updateBlogComment,
+    updateBlogCommentReaction,
+} from '@/api/blogApi';
 import { useAuth } from '@/auth/Auth';
 import CommentEditor from '@/components/comments/CommentEditor';
 import CommentList from '@/components/comments/CommentList';
@@ -37,6 +42,10 @@ export default function BlogComments({ comments: initialComments, owner, id }: B
         setComments(resp.data.comments ?? null);
     };
 
+    const handleReact = async (commentId: string, reactionType: string) => {
+        const resp = await updateBlogCommentReaction({ owner, id, commentId }, reactionType);
+        setComments(resp.data.comments ?? null);
+    };
     return (
         <>
             <Divider sx={{ my: 3 }} />
@@ -51,6 +60,7 @@ export default function BlogComments({ comments: initialComments, owner, id }: B
                 onDelete={user ? handleDelete : undefined}
                 threaded
                 onSubmitReply={user ? handleSubmitReply : undefined}
+                onReact={user ? handleReact : undefined}
             />
             {user ? (
                 <CommentEditor<Blog, { owner: string; id: string }>

--- a/frontend/src/app/[locale]/(blog)/blog/[...id]/BlogComments.tsx
+++ b/frontend/src/app/[locale]/(blog)/blog/[...id]/BlogComments.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '@/auth/Auth';
 import CommentEditor from '@/components/comments/CommentEditor';
 import CommentList from '@/components/comments/CommentList';
 import { Link } from '@/components/navigation/Link';
-import { Blog } from '@jackstenglein/chess-dojo-common/src/blog/api';
+import { Blog, BlogCommentReactionType } from '@jackstenglein/chess-dojo-common/src/blog/api';
 import { Comment } from '@jackstenglein/chess-dojo-common/src/database/timeline';
 import { Divider, Typography } from '@mui/material';
 import { useTranslations } from 'next-intl';
@@ -42,7 +42,7 @@ export default function BlogComments({ comments: initialComments, owner, id }: B
         setComments(resp.data.comments ?? null);
     };
 
-    const handleReact = async (commentId: string, reactionType: string) => {
+    const handleReact = async (commentId: string, reactionType: BlogCommentReactionType) => {
         const resp = await updateBlogCommentReaction({ owner, id, commentId }, reactionType);
         setComments(resp.data.comments ?? null);
     };

--- a/frontend/src/components/comments/CommentList.test.tsx
+++ b/frontend/src/components/comments/CommentList.test.tsx
@@ -1,5 +1,5 @@
 import type { Comment } from '@jackstenglein/chess-dojo-common/src/database/timeline';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import CommentList from './CommentList';
 
@@ -290,6 +290,57 @@ describe('CommentList', () => {
             // Reply 1 still hidden since we haven't submitted yet
             expect(screen.queryByText('Reply 1')).not.toBeInTheDocument();
             expect(screen.getByText('Show 1 more reply')).toBeInTheDocument();
+        });
+    });
+
+    describe('Reactions', () => {
+        it('only shows reaction controls when a persistence callback is provided', () => {
+            const { unmount } = renderWithIntl(<CommentList comments={[makeComment()]} />);
+
+            expect(screen.queryByLabelText('Add reaction')).not.toBeInTheDocument();
+
+            unmount();
+            renderWithIntl(
+                <CommentList
+                    comments={[makeComment()]}
+                    onReact={vi.fn().mockResolvedValue(undefined)}
+                />,
+            );
+
+            expect(screen.getByLabelText('Add reaction')).toBeInTheDocument();
+        });
+
+        it('passes the selected reaction to the persistence callback', async () => {
+            const onReact = vi.fn().mockResolvedValue(undefined);
+            renderWithIntl(<CommentList comments={[makeComment()]} onReact={onReact} />);
+
+            fireEvent.click(screen.getByLabelText('Add reaction'));
+            fireEvent.click(screen.getByRole('button', { name: '👍' }));
+
+            await waitFor(() => expect(onReact).toHaveBeenCalledWith('c1', '👍'));
+        });
+
+        it('rolls back an optimistic reaction when persistence fails', async () => {
+            let rejectRequest: (reason: Error) => void = () => undefined;
+            const onReact = vi.fn(
+                () =>
+                    new Promise<void>((_resolve, reject) => {
+                        rejectRequest = reject;
+                    }),
+            );
+            renderWithIntl(<CommentList comments={[makeComment()]} onReact={onReact} />);
+
+            fireEvent.click(screen.getByLabelText('Add reaction'));
+            fireEvent.click(screen.getByRole('button', { name: '👍' }));
+
+            expect(screen.getByRole('button', { name: '👍 1' })).toBeInTheDocument();
+
+            act(() => rejectRequest(new Error('Unable to save reaction')));
+
+            await waitFor(() => {
+                expect(screen.queryByRole('button', { name: '👍 1' })).not.toBeInTheDocument();
+            });
+            expect(screen.getByText('Unable to save reaction')).toBeInTheDocument();
         });
     });
 });

--- a/frontend/src/components/comments/CommentList.tsx
+++ b/frontend/src/components/comments/CommentList.tsx
@@ -4,6 +4,7 @@ import { toDojoDateString, toDojoTimeString } from '@/components/calendar/displa
 import { Link } from '@/components/navigation/Link';
 import Avatar from '@/profile/Avatar';
 import { Comment } from '@jackstenglein/chess-dojo-common/src/database/timeline';
+import AddReactionOutlinedIcon from '@mui/icons-material/AddReactionOutlined';
 import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
@@ -19,6 +20,7 @@ import {
     DialogTitle,
     IconButton,
     Paper,
+    Popover,
     Stack,
     TextField,
     Tooltip,
@@ -39,6 +41,7 @@ interface CommentListProps {
     onDelete?: (commentId: string) => Promise<void>;
     threaded?: boolean;
     onSubmitReply?: (parentId: string, content: string) => Promise<void>;
+    onReact?: (commentId: string, reactionType: string) => Promise<void>;
 }
 
 const CommentList: React.FC<CommentListProps> = ({
@@ -49,6 +52,7 @@ const CommentList: React.FC<CommentListProps> = ({
     onDelete,
     threaded,
     onSubmitReply,
+    onReact,
 }) => {
     const t = useTranslations('comments');
     const [replyingTo, setReplyingTo] = useState<string | null>(null);
@@ -123,6 +127,7 @@ const CommentList: React.FC<CommentListProps> = ({
                                 onEdit={onEdit}
                                 onDelete={onDelete}
                                 onReply={onSubmitReply ? handleReplyClick : undefined}
+                                onReact={onReact}
                             />
                             {replyingTo === thread.root.id && onSubmitReply && (
                                 <InlineReplyEditor
@@ -166,6 +171,7 @@ const CommentList: React.FC<CommentListProps> = ({
                                         onEdit={onEdit}
                                         onDelete={onDelete}
                                         onReply={onSubmitReply ? handleReplyClick : undefined}
+                                        onReact={onReact}
                                     />
                                     {replyingTo === reply.id && onSubmitReply && (
                                         <InlineReplyEditor
@@ -205,6 +211,7 @@ const CommentList: React.FC<CommentListProps> = ({
                     comment={comment}
                     onEdit={onEdit}
                     onDelete={onDelete}
+                    onReact={onReact}
                 />
             ))}
         </Stack>
@@ -216,6 +223,7 @@ interface CommentListItemProps {
     onEdit?: (commentId: string, content: string) => Promise<void>;
     onDelete?: (commentId: string) => Promise<void>;
     onReply?: (parentCommentId: string) => void;
+    onReact?: (commentId: string, reactionType: string) => Promise<void>;
 }
 
 const CommentListItem: React.FC<CommentListItemProps> = ({
@@ -223,6 +231,7 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
     onEdit,
     onDelete,
     onReply,
+    onReact,
 }) => {
     const t = useTranslations('comments');
     const { user } = useAuth();
@@ -234,7 +243,46 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const editRequest = useRequest();
     const deleteRequest = useRequest();
+    const [reactionAnchorEl, setReactionAnchorEl] = useState<HTMLElement | null>(null);
+    const reactionOpen = Boolean(reactionAnchorEl);
 
+    const [localReactions, setLocalReactions] = useState(comment.reactions || {});
+    const REACTION_OPTIONS = ['👍', '❤️', '😂', '🔥', '🎉'];
+
+    const handleReactionClick = (event: React.MouseEvent<HTMLElement>) => {
+        setReactionAnchorEl(event.currentTarget);
+    };
+
+    const handleReactionClose = () => {
+        setReactionAnchorEl(null);
+    };
+
+    const handleSelectReaction = (emoji: string) => {
+        if (!user) return;
+
+        setLocalReactions((prev) => {
+            const existingReaction = prev[user.username];
+            const currentTypes = existingReaction?.types || [];
+            const newTypes = currentTypes.includes(emoji) ? [] : [emoji];
+
+            return {
+                ...prev,
+                [user.username]: {
+                    username: user.username,
+                    displayName: user.displayName,
+                    cohort: user.dojoCohort,
+                    updatedAt: new Date().toISOString(),
+                    types: newTypes,
+                },
+            };
+        });
+        if (onReact) {
+            onReact(comment.id, emoji).catch(() => {
+                // ignore errors for now since backend is pending
+            });
+        }
+        handleReactionClose();
+    };
     useEffect(() => {
         const el = contentRef.current;
         if (el) {
@@ -420,7 +468,95 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
                         {toDojoTimeString(createdAt, timezone, timeFormat)}
                         {isEdited && ` • ${t('edited')}`}
                     </Typography>
+                    {user && (
+                        <Tooltip title='Add Reaction'>
+                            <IconButton size='small' onClick={handleReactionClick}>
+                                <AddReactionOutlinedIcon
+                                    fontSize='small'
+                                    sx={{ color: 'text.secondary' }}
+                                />
+                            </IconButton>
+                        </Tooltip>
+                    )}
+                    {Object.values(localReactions).some((r) => r.types && r.types.length > 0) && (
+                        <Stack direction='row' spacing={0.5} mt={1} flexWrap='wrap'>
+                            {REACTION_OPTIONS.map((emoji) => {
+                                const reactingUsers = Object.values(localReactions).filter((r) =>
+                                    r.types?.includes(emoji),
+                                );
+                                const count = reactingUsers.length;
+
+                                if (count === 0) return null;
+
+                                const isSelectedByMe =
+                                    localReactions[user?.username || '']?.types?.includes(emoji);
+                                const MAX_NAMES = 3;
+                                let tooltipText = '';
+
+                                if (count <= MAX_NAMES) {
+                                    tooltipText = reactingUsers
+                                        .map((r) => r.displayName)
+                                        .join(', ');
+                                } else {
+                                    const firstFew = reactingUsers
+                                        .slice(0, MAX_NAMES)
+                                        .map((r) => r.displayName)
+                                        .join(', ');
+                                    tooltipText = `${firstFew} and ${count - MAX_NAMES} others`;
+                                }
+                                return (
+                                    <Tooltip key={emoji} title={tooltipText} placement='bottom'>
+                                        <Button
+                                            size='small'
+                                            variant='outlined'
+                                            onClick={() => handleSelectReaction(emoji)}
+                                            sx={{
+                                                borderRadius: 4,
+                                                py: 0.25,
+                                                px: 1,
+                                                minWidth: 0,
+                                                textTransform: 'none',
+                                                borderColor: isSelectedByMe
+                                                    ? 'primary.main'
+                                                    : 'divider',
+                                                backgroundColor: isSelectedByMe
+                                                    ? 'action.selected'
+                                                    : 'transparent',
+                                                color: isSelectedByMe
+                                                    ? 'primary.main'
+                                                    : 'text.secondary',
+                                            }}
+                                        >
+                                            {emoji}{' '}
+                                            <Typography variant='caption' sx={{ ml: 0.5 }}>
+                                                {count}
+                                            </Typography>
+                                        </Button>
+                                    </Tooltip>
+                                );
+                            })}
+                        </Stack>
+                    )}
                 </Stack>
+                <Popover
+                    open={reactionOpen}
+                    anchorEl={reactionAnchorEl}
+                    onClose={handleReactionClose}
+                    anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+                    transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+                >
+                    <Stack direction='row' spacing={0.5} p={0.5}>
+                        {REACTION_OPTIONS.map((emoji) => (
+                            <IconButton
+                                key={emoji}
+                                size='small'
+                                onClick={() => handleSelectReaction(emoji)}
+                            >
+                                {emoji}
+                            </IconButton>
+                        ))}
+                    </Stack>
+                </Popover>
             </Stack>
 
             <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>

--- a/frontend/src/components/comments/CommentList.tsx
+++ b/frontend/src/components/comments/CommentList.tsx
@@ -3,6 +3,10 @@ import { useAuth } from '@/auth/Auth';
 import { toDojoDateString, toDojoTimeString } from '@/components/calendar/displayDate';
 import { Link } from '@/components/navigation/Link';
 import Avatar from '@/profile/Avatar';
+import {
+    BLOG_COMMENT_REACTION_TYPES,
+    BlogCommentReactionType,
+} from '@jackstenglein/chess-dojo-common/src/blog/api';
 import { Comment } from '@jackstenglein/chess-dojo-common/src/database/timeline';
 import AddReactionOutlinedIcon from '@mui/icons-material/AddReactionOutlined';
 import CloseIcon from '@mui/icons-material/Close';
@@ -32,6 +36,7 @@ import { groupCommentsIntoThreads } from './threadComments';
 
 const COMMENT_LINE_CLAMP = 4;
 const COLLAPSE_REPLY_THRESHOLD = 3;
+const REACTION_OPTIONS = BLOG_COMMENT_REACTION_TYPES;
 
 interface CommentListProps {
     comments: Comment[] | null;
@@ -41,7 +46,7 @@ interface CommentListProps {
     onDelete?: (commentId: string) => Promise<void>;
     threaded?: boolean;
     onSubmitReply?: (parentId: string, content: string) => Promise<void>;
-    onReact?: (commentId: string, reactionType: string) => Promise<void>;
+    onReact?: (commentId: string, reactionType: BlogCommentReactionType) => Promise<void>;
 }
 
 const CommentList: React.FC<CommentListProps> = ({
@@ -223,7 +228,7 @@ interface CommentListItemProps {
     onEdit?: (commentId: string, content: string) => Promise<void>;
     onDelete?: (commentId: string) => Promise<void>;
     onReply?: (parentCommentId: string) => void;
-    onReact?: (commentId: string, reactionType: string) => Promise<void>;
+    onReact?: (commentId: string, reactionType: BlogCommentReactionType) => Promise<void>;
 }
 
 const CommentListItem: React.FC<CommentListItemProps> = ({
@@ -243,11 +248,13 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const editRequest = useRequest();
     const deleteRequest = useRequest();
+    const reactionRequest = useRequest();
+    const reactionInFlight = useRef(false);
     const [reactionAnchorEl, setReactionAnchorEl] = useState<HTMLElement | null>(null);
     const reactionOpen = Boolean(reactionAnchorEl);
 
-    const [localReactions, setLocalReactions] = useState(comment.reactions || {});
-    const REACTION_OPTIONS = ['👍', '❤️', '😂', '🔥', '🎉'];
+    const [optimisticReactions, setOptimisticReactions] = useState<typeof comment.reactions>();
+    const localReactions = optimisticReactions ?? comment.reactions ?? {};
 
     const handleReactionClick = (event: React.MouseEvent<HTMLElement>) => {
         setReactionAnchorEl(event.currentTarget);
@@ -257,41 +264,53 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
         setReactionAnchorEl(null);
     };
 
-    const handleSelectReaction = (emoji: string) => {
-        if (!user) return;
+    const handleSelectReaction = (emoji: BlogCommentReactionType) => {
+        if (!user || !onReact || reactionInFlight.current) return;
 
-        setLocalReactions((prev) => {
-            const existingReaction = prev[user.username];
-            const currentTypes = existingReaction?.types || [];
-            const newTypes = currentTypes.includes(emoji) ? [] : [emoji];
+        reactionInFlight.current = true;
 
-            return {
-                ...prev,
-                [user.username]: {
-                    username: user.username,
-                    displayName: user.displayName,
-                    cohort: user.dojoCohort,
-                    updatedAt: new Date().toISOString(),
-                    types: newTypes,
-                },
-            };
-        });
-        if (onReact) {
-            onReact(comment.id, emoji).catch(() => {
-                // ignore errors for now since backend is pending
+        const previousReactions = localReactions;
+        const existingReaction = previousReactions[user.username];
+        const isRemoving = existingReaction?.types?.includes(emoji) ?? false;
+        const nextReactions = isRemoving
+            ? Object.fromEntries(
+                  Object.entries(previousReactions).filter(
+                      ([username]) => username !== user.username,
+                  ),
+              )
+            : {
+                  ...previousReactions,
+                  [user.username]: {
+                      username: user.username,
+                      displayName: user.displayName,
+                      cohort: user.dojoCohort,
+                      updatedAt: new Date().toISOString(),
+                      types: [emoji],
+                  },
+              };
+
+        setOptimisticReactions(nextReactions);
+        reactionRequest.onStart();
+        onReact(comment.id, emoji)
+            .then(() => {
+                setOptimisticReactions(undefined);
+                reactionRequest.onSuccess();
+            })
+            .catch((err: unknown) => {
+                setOptimisticReactions(undefined);
+                reactionRequest.onFailure(err);
+            })
+            .finally(() => {
+                reactionInFlight.current = false;
             });
-        }
         handleReactionClose();
     };
+
     useEffect(() => {
         const el = contentRef.current;
         if (el) {
             setIsClamped(el.scrollHeight > el.clientHeight);
         }
-    }, [comment.content]);
-
-    useEffect(() => {
-        setExpanded(false);
     }, [comment.content]);
 
     const createdAt = new Date(comment.createdAt);
@@ -311,6 +330,7 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
         onEdit(comment.id, content)
             .then(() => {
                 editRequest.onSuccess();
+                setExpanded(false);
                 setEditing(false);
             })
             .catch((err: unknown) => {
@@ -337,6 +357,7 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
         <Stack direction='row' spacing={1.5} width={1}>
             <RequestSnackbar request={editRequest} />
             <RequestSnackbar request={deleteRequest} />
+            <RequestSnackbar request={reactionRequest} />
 
             <Avatar username={comment.owner} displayName={comment.ownerDisplayName} size={40} />
 
@@ -468,9 +489,14 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
                         {toDojoTimeString(createdAt, timezone, timeFormat)}
                         {isEdited && ` • ${t('edited')}`}
                     </Typography>
-                    {user && (
-                        <Tooltip title='Add Reaction'>
-                            <IconButton size='small' onClick={handleReactionClick}>
+                    {user && onReact && (
+                        <Tooltip title={t('addReaction')}>
+                            <IconButton
+                                size='small'
+                                onClick={handleReactionClick}
+                                disabled={reactionRequest.isLoading()}
+                                aria-label={t('addReaction')}
+                            >
                                 <AddReactionOutlinedIcon
                                     fontSize='small'
                                     sx={{ color: 'text.secondary' }}
@@ -502,14 +528,22 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
                                         .slice(0, MAX_NAMES)
                                         .map((r) => r.displayName)
                                         .join(', ');
-                                    tooltipText = `${firstFew} and ${count - MAX_NAMES} others`;
+                                    tooltipText = t('reactedByOthers', {
+                                        names: firstFew,
+                                        count: count - MAX_NAMES,
+                                    });
                                 }
                                 return (
                                     <Tooltip key={emoji} title={tooltipText} placement='bottom'>
                                         <Button
                                             size='small'
                                             variant='outlined'
-                                            onClick={() => handleSelectReaction(emoji)}
+                                            onClick={
+                                                onReact
+                                                    ? () => handleSelectReaction(emoji)
+                                                    : undefined
+                                            }
+                                            disabled={reactionRequest.isLoading()}
                                             sx={{
                                                 borderRadius: 4,
                                                 py: 0.25,
@@ -551,6 +585,7 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
                                 key={emoji}
                                 size='small'
                                 onClick={() => handleSelectReaction(emoji)}
+                                disabled={reactionRequest.isLoading()}
                             >
                                 {emoji}
                             </IconButton>


### PR DESCRIPTION
this PR adds emoji reactions to blog comments on the frontend.
users can react to a comment with an emoji, toggle their reaction on/off, and see who reacted via hover.

this PR only handles the frontend + shared types.
the backend endpoint (PUT /blog/comments/reactions/:owner/:id) and DynamoDB logic still need to be implemented.

demo
<img width="1106" height="678" alt="Screenshot 2026-03-09 213334" src="https://github.com/user-attachments/assets/f8ca4838-b4b7-4bef-9ef1-ad4730fdd0b1" />
