### PR TITLE
fix(#2070): smooth game switching in directories without page reload

### DIFF
--- a/frontend/src/components/profile/directories/DirectoriesSection.tsx
+++ b/frontend/src/components/profile/directories/DirectoriesSection.tsx
@@ -4,6 +4,7 @@ import { useRequest } from '@/api/Request';
 import { NavigationMenu } from '@/components/directories/navigation/NavigationMenu';
 import { GameCell } from '@/components/games/list/GameListItem';
 import { PAGE_SIZE_OPTIONS } from '@/components/ui/pagination';
+import useGame from '@/context/useGame';
 import { GameResult } from '@/database/game.ts';
 import { useDataGridContextMenu } from '@/hooks/useDataGridContextMenu';
 import { useNextSearchParams } from '@/hooks/useNextSearchParams';
@@ -105,6 +106,7 @@ const DirectorySection = ({
         directory: 'home',
     });
     const router = useRouter();
+    const { onNavigateToGame } = useGame();
 
     const [columnVisibility, setColumnVisibility] = useLocalStorage<GridColumnVisibilityModel>(
         `/DirectoryTable/${namespace}/visibility`,
@@ -191,14 +193,19 @@ const DirectorySection = ({
             });
             setRowSelectionModel({ type: 'include', ids: new Set() });
         } else {
-            const url = `/games/${params.row.metadata.cohort.replaceAll('+', '%2B')}/${params.row.metadata.id.replaceAll(
-                '?',
-                '%3F',
-            )}?directory=${directory.id}&directoryOwner=${directory.owner}`;
-            if (event.shiftKey) {
-                window.open(url, '_blank');
+            const { cohort, id } = params.row.metadata;
+            if (onNavigateToGame && !event.shiftKey) {
+                onNavigateToGame(cohort, id);
             } else {
-                router.push(url);
+                const url = `/games/${cohort.replaceAll('+', '%2B')}/${id.replaceAll(
+                    '?',
+                    '%3F',
+                )}?directory=${directory.id}&directoryOwner=${directory.owner}`;
+                if (event.shiftKey) {
+                    window.open(url, '_blank');
+                } else {
+                    router.push(url);
+                }
             }
         }
     };

--- a/frontend/src/context/useGame.ts
+++ b/frontend/src/context/useGame.ts
@@ -6,6 +6,8 @@ export interface GameContextType {
     onUpdateGame?: (g: Game) => void;
     isOwner?: boolean;
     unsaved?: boolean;
+    /** If defined, the Directories tab calls this instead of router.push when clicking a game. */
+    onNavigateToGame?: (cohort: string, id: string) => void;
 }
 
 export const GameContext = createContext<GameContextType>({});

--- a/frontend/src/games/mergeSuggestedVariations.ts
+++ b/frontend/src/games/mergeSuggestedVariations.ts
@@ -1,0 +1,81 @@
+import { Game, PositionComment } from '@/database/game';
+import { Chess, Move } from '@jackstenglein/chess';
+
+/**
+ * Merges suggested variations from position comments into the game's PGN.
+ * Mutates the game object in place.
+ */
+export function mergeSuggestedVariations(game: Game) {
+    const suggestions: Record<string, PositionComment[]> = {};
+    for (const [fen, positionComments] of Object.entries(game.positionComments || {})) {
+        for (const comment of Object.values(positionComments)) {
+            if (comment.suggestedVariation) {
+                suggestions[fen] = (suggestions[fen] ?? []).concat(comment);
+            }
+        }
+    }
+
+    if (Object.keys(suggestions).length === 0) {
+        return;
+    }
+
+    const chess = new Chess({ pgn: game.pgn });
+    const stack: Move[] = [];
+    let move = null;
+
+    do {
+        const comments = suggestions[chess.normalizedFen(move)];
+        if (comments) {
+            mergeFromMove(chess, move, comments);
+        }
+
+        const nextMove = chess.nextMove(move);
+        if (nextMove) {
+            stack.push(nextMove);
+        }
+        for (const variation of move?.variations ?? []) {
+            stack.push(variation[0]);
+        }
+
+        move = stack.pop() ?? null;
+    } while (move);
+
+    game.pgn = chess.renderPgn();
+}
+
+function mergeFromMove(chess: Chess, move: Move | null, comments: PositionComment[]) {
+    comments.sort((lhs, rhs) => lhs.createdAt.localeCompare(rhs.createdAt));
+
+    for (const comment of comments) {
+        const commentChess = new Chess({ pgn: comment.suggestedVariation });
+        recursiveMergeLine(commentChess.history(), chess, move, comment);
+    }
+}
+
+function recursiveMergeLine(
+    line: Move[],
+    target: Chess,
+    currentTargetMove: Move | null,
+    comment: PositionComment,
+) {
+    for (const move of line) {
+        const newTargetMove = target.move(move.san, {
+            previousMove: currentTargetMove,
+            skipSeek: true,
+        });
+        if (!newTargetMove) {
+            return;
+        }
+
+        target.setCommand(
+            'dojoComment',
+            `${comment.owner.username},${comment.owner.displayName},${comment.id}`,
+            newTargetMove,
+        );
+        for (const variation of move.variations) {
+            recursiveMergeLine(variation, target, currentTargetMove, comment);
+        }
+
+        currentTargetMove = newTargetMove;
+    }
+}

--- a/frontend/src/games/view/GamePage.tsx
+++ b/frontend/src/games/view/GamePage.tsx
@@ -25,9 +25,12 @@ import {
 import { Box } from '@mui/material';
 import { isAxiosError } from 'axios';
 import { notFound } from 'next/navigation';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { MissingGameDataPreflight } from '../edit/MissingGameDataPreflight';
 import PgnErrorBoundary from './PgnErrorBoundary';
+
+/** Module-level cache so it survives React Strict Mode remounts in dev. */
+const gameCache = new Map<string, Game>();
 
 const GamePage = ({ cohort: initialCohort, id: initialId }: { cohort: string; id: string }) => {
     const api = useApi();
@@ -44,7 +47,6 @@ const GamePage = ({ cohort: initialCohort, id: initialId }: { cohort: string; id
     const [currentCohort, setCurrentCohort] = useState(initialCohort);
     const [currentId, setCurrentId] = useState(initialId);
     const [currentGame, setCurrentGame] = useState<Game | undefined>();
-    const gameCacheRef = useRef(new Map<string, Game>());
 
     const cohort = currentCohort;
     const id = currentId;
@@ -52,7 +54,7 @@ const GamePage = ({ cohort: initialCohort, id: initialId }: { cohort: string; id
     const reset = request.reset;
     useEffect(() => {
         if (cohort && id) {
-            const cached = gameCacheRef.current.get(`${cohort}/${id}`);
+            const cached = gameCache.get(`${cohort}/${id}`);
             if (cached) {
                 setCurrentGame(cached);
                 return;
@@ -62,13 +64,13 @@ const GamePage = ({ cohort: initialCohort, id: initialId }: { cohort: string; id
     }, [cohort, id, reset]);
 
     useEffect(() => {
-        if (!request.isSent() && cohort && id && !gameCacheRef.current.has(`${cohort}/${id}`)) {
+        if (!request.isSent() && cohort && id && !gameCache.has(`${cohort}/${id}`)) {
             request.onStart();
             api.getGame(cohort, id)
                 .then((response) => {
                     const game = response.data;
                     mergeSuggestedVariations(game);
-                    gameCacheRef.current.set(`${cohort}/${id}`, game);
+                    gameCache.set(`${cohort}/${id}`, game);
                     setCurrentGame(game);
                     request.onSuccess(game);
                 })
@@ -155,7 +157,7 @@ const GamePage = ({ cohort: initialCohort, id: initialId }: { cohort: string; id
         const current = currentGame ?? request.data;
         const updated = { ...g, pgn: current?.pgn ?? g.pgn };
         setCurrentGame(updated);
-        gameCacheRef.current.set(`${updated.cohort}/${updated.id}`, updated);
+        gameCache.set(`${updated.cohort}/${updated.id}`, updated);
         request.onSuccess(updated);
     };
 

--- a/frontend/src/games/view/GamePage.tsx
+++ b/frontend/src/games/view/GamePage.tsx
@@ -10,11 +10,12 @@ import { DefaultUnderboardTab } from '@/board/pgn/boardTools/underboard/underboa
 import PgnBoard from '@/board/pgn/PgnBoard';
 import { GameMoveButtonExtras } from '@/components/games/view/GameMoveButtonExtras';
 import { GameContext } from '@/context/useGame';
-import { Game, PositionComment } from '@/database/game';
+import { Game } from '@/database/game';
+import { mergeSuggestedVariations } from '@/games/mergeSuggestedVariations';
 import { useNextSearchParams } from '@/hooks/useNextSearchParams';
 import LoadingPage from '@/loading/LoadingPage';
 import { logger } from '@/logging/logger';
-import { Chess, EventType as ChessEventType, Move } from '@jackstenglein/chess';
+import { Chess, EventType as ChessEventType } from '@jackstenglein/chess';
 import {
     GameHeader,
     GameImportTypes,
@@ -24,11 +25,11 @@ import {
 import { Box } from '@mui/material';
 import { isAxiosError } from 'axios';
 import { notFound } from 'next/navigation';
-import { useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { MissingGameDataPreflight } from '../edit/MissingGameDataPreflight';
 import PgnErrorBoundary from './PgnErrorBoundary';
 
-const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
+const GamePage = ({ cohort: initialCohort, id: initialId }: { cohort: string; id: string }) => {
     const api = useApi();
     const request = useRequest<Game>();
     const featureRequest = useRequest();
@@ -39,20 +40,36 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
     });
     const firstLoad = searchParams.get('firstLoad') === 'true';
 
+    // Track the current game separately so we can swap without navigation
+    const [currentCohort, setCurrentCohort] = useState(initialCohort);
+    const [currentId, setCurrentId] = useState(initialId);
+    const [currentGame, setCurrentGame] = useState<Game | undefined>();
+    const gameCacheRef = useRef(new Map<string, Game>());
+
+    const cohort = currentCohort;
+    const id = currentId;
+
     const reset = request.reset;
     useEffect(() => {
         if (cohort && id) {
+            const cached = gameCacheRef.current.get(`${cohort}/${id}`);
+            if (cached) {
+                setCurrentGame(cached);
+                return;
+            }
             reset();
         }
     }, [cohort, id, reset]);
 
     useEffect(() => {
-        if (!request.isSent() && cohort && id) {
+        if (!request.isSent() && cohort && id && !gameCacheRef.current.has(`${cohort}/${id}`)) {
             request.onStart();
             api.getGame(cohort, id)
                 .then((response) => {
                     const game = response.data;
                     mergeSuggestedVariations(game);
+                    gameCacheRef.current.set(`${cohort}/${id}`, game);
+                    setCurrentGame(game);
                     request.onSuccess(game);
                 })
                 .catch((err) => {
@@ -61,11 +78,20 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
         }
     }, [request, api, cohort, id]);
 
+    const onNavigateToGame = useCallback((newCohort: string, newId: string) => {
+        setCurrentCohort(newCohort);
+        setCurrentId(newId);
+        // Update URL without triggering Next.js navigation
+        const newUrl = `/games/${newCohort.replaceAll('+', '%2B')}/${newId.replaceAll('?', '%3F')}${window.location.search}`;
+        window.history.replaceState(null, '', newUrl);
+    }, []);
+
     if (status === AuthStatus.Loading) {
         return <LoadingPage />;
     }
 
     if (
+        !currentGame &&
         request.isFailure() &&
         isAxiosError(request.error) &&
         request.error.response?.status === 404
@@ -74,7 +100,7 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
     }
 
     const onSave = (headers: GameHeader, orientation: GameOrientation) => {
-        const game = request.data;
+        const game = currentGame ?? request.data;
 
         if (game === undefined) {
             logger.error?.('Game is unexpectedly undefined');
@@ -126,7 +152,11 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
     };
 
     const onUpdateGame = (g: Game) => {
-        request.onSuccess({ ...g, pgn: request.data?.pgn ?? g.pgn });
+        const current = currentGame ?? request.data;
+        const updated = { ...g, pgn: current?.pgn ?? g.pgn };
+        setCurrentGame(updated);
+        gameCacheRef.current.set(`${updated.cohort}/${updated.id}`, updated);
+        request.onSuccess(updated);
     };
 
     const onInitialize = (_: BoardApi, chess: Chess) => {
@@ -144,9 +174,10 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
         }
     };
 
-    const isOwner = request.data?.owner === user?.username;
-    const showPreflight =
-        isOwner && firstLoad && request.data !== undefined && isMissingData(request.data);
+    // Use currentGame to keep the board visible while switching games
+    const game = currentGame ?? request.data;
+    const isOwner = game?.owner === user?.username;
+    const showPreflight = isOwner && firstLoad && game !== undefined && isMissingData(game);
 
     return (
         <Box
@@ -160,17 +191,18 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
             <RequestSnackbar request={featureRequest} showSuccess />
             <RequestSnackbar request={updateRequest} />
 
-            <PgnErrorBoundary pgn={request.data?.pgn} game={request.data}>
+            <PgnErrorBoundary pgn={game?.pgn} game={game}>
                 <GameContext.Provider
                     value={{
-                        game: request.data,
+                        game,
                         onUpdateGame,
                         isOwner,
+                        onNavigateToGame,
                     }}
                 >
                     <PgnBoard
-                        pgn={request.data?.pgn}
-                        startOrientation={request.data?.orientation}
+                        pgn={game?.pgn}
+                        startOrientation={game?.orientation}
                         underboardTabs={[
                             ...(user ? [DefaultUnderboardTab.Directories] : []),
                             DefaultUnderboardTab.Tags,
@@ -182,8 +214,8 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
                             DefaultUnderboardTab.Share,
                             DefaultUnderboardTab.Settings,
                         ]}
-                        allowMoveDeletion={request.data?.owner === user?.username}
-                        allowDeleteBefore={request.data?.owner === user?.username}
+                        allowMoveDeletion={game?.owner === user?.username}
+                        allowDeleteBefore={game?.owner === user?.username}
                         showElapsedMoveTimes
                         slots={{
                             moveButtonExtras: GameMoveButtonExtras,
@@ -192,12 +224,12 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
                     />
                 </GameContext.Provider>
             </PgnErrorBoundary>
-            {request.data && (
+            {game && (
                 <MissingGameDataPreflight
                     skippable
                     open={showPreflight}
-                    initHeaders={request.data.headers}
-                    initOrientation={request.data.orientation}
+                    initHeaders={game.headers}
+                    initOrientation={game.orientation}
                     loading={updateRequest.isLoading()}
                     onSubmit={onSave}
                     onClose={() => updateSearchParams({ firstLoad: 'false' })}
@@ -210,85 +242,3 @@ const GamePage = ({ cohort, id }: { cohort: string; id: string }) => {
 };
 
 export default GamePage;
-
-function mergeSuggestedVariations(game: Game) {
-    const suggestions: Record<string, PositionComment[]> = {};
-    for (const [fen, positionComments] of Object.entries(game.positionComments || {})) {
-        for (const comment of Object.values(positionComments)) {
-            if (comment.suggestedVariation) {
-                suggestions[fen] = (suggestions[fen] ?? []).concat(comment);
-            }
-        }
-    }
-
-    if (Object.keys(suggestions).length === 0) {
-        return;
-    }
-
-    const chess = new Chess({ pgn: game.pgn });
-    const stack: Move[] = [];
-    let move = null;
-
-    do {
-        const comments = suggestions[chess.normalizedFen(move)];
-        if (comments) {
-            mergeFromMove(chess, move, comments);
-        }
-
-        const nextMove = chess.nextMove(move);
-        if (nextMove) {
-            stack.push(nextMove);
-        }
-        for (const variation of move?.variations ?? []) {
-            stack.push(variation[0]);
-        }
-
-        move = stack.pop() ?? null;
-    } while (move);
-
-    game.pgn = chess.renderPgn();
-}
-
-function mergeFromMove(chess: Chess, move: Move | null, comments: PositionComment[]) {
-    comments.sort((lhs, rhs) => lhs.createdAt.localeCompare(rhs.createdAt));
-
-    for (const comment of comments) {
-        const commentChess = new Chess({ pgn: comment.suggestedVariation });
-        recursiveMergeLine(commentChess.history(), chess, move, comment);
-    }
-}
-
-/**
- * Recursively merges the given line into the target Chess instance.
- * @param line The line to merge into the Chess instance.
- * @param target The target Chess to merge the line into.
- * @param currentTargetMove The current move to start from in the target Chess.
- * @param comment The comment that generated the merge.
- */
-function recursiveMergeLine(
-    line: Move[],
-    target: Chess,
-    currentTargetMove: Move | null,
-    comment: PositionComment,
-) {
-    for (const move of line) {
-        const newTargetMove = target.move(move.san, {
-            previousMove: currentTargetMove,
-            skipSeek: true,
-        });
-        if (!newTargetMove) {
-            return;
-        }
-
-        target.setCommand(
-            'dojoComment',
-            `${comment.owner.username},${comment.owner.displayName},${comment.id}`,
-            newTargetMove,
-        );
-        for (const variation of move.variations) {
-            recursiveMergeLine(variation, target, currentTargetMove, comment);
-        }
-
-        currentTargetMove = newTargetMove;
-    }
-}


### PR DESCRIPTION
## Summary
- Swap games in-place via React state + `window.history.replaceState` instead of `router.push`, which avoids the Next.js App Router remount that caused a flash on every click from the Directories tab
- The underboard tab (e.g. Directories) no longer resets on game switch since the component stays mounted
- Previously visited games are cached in memory for instant revisits
- Shift-click still opens in a new tab

## Changes
- `src/context/useGame.ts` - Added `onNavigateToGame` to `GameContextType`
- `src/games/view/GamePage.tsx` - State-based game tracking (`currentCohort`/`currentId`/`currentGame`), in-memory game cache via `useRef`, `onNavigateToGame` callback using `replaceState`
- `src/components/profile/directories/DirectoriesSection.tsx` - Calls `useGame().onNavigateToGame` instead of `router.push` when available
- `src/games/mergeSuggestedVariations.ts` - Extracted from GamePage, no logic changes

## Test plan
- [x] Open a game from a directory, click the Directories underboard tab
- [x] Click another game - should load without a page flash
- [x] Check that the URL updates to the new game
- [x] Check the underboard tab stays on Directories (not reset to Editor/Tags)
- [x] Click back to a previously viewed game - should load instantly from cache
- [x] Shift-click a game - should open in a new tab with normal navigation
- [x] Open a game directly via URL (not from a directory) - should work as before
- [x] Check that games with suggested variations still display them
- [x] shift feature ideas from issue to a new feature request issue