### PR TITLE
feat(#2133): persist column order and active tab across reloads

### DIFF
--- a/frontend/src/board/pgn/boardTools/underboard/Underboard.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/Underboard.tsx
@@ -25,7 +25,14 @@ import {
     ToggleButtonProps,
     Tooltip,
 } from '@mui/material';
-import React, { forwardRef, Fragment, useImperativeHandle, useState } from 'react';
+import React, {
+    forwardRef,
+    Fragment,
+    useCallback,
+    useImperativeHandle,
+    useMemo,
+    useState,
+} from 'react';
 import { Resizable, ResizeCallbackData } from 'react-resizable';
 import { useLocalStorage } from 'usehooks-ts';
 import { AuthStatus, useAuth } from '../../../../auth/Auth';
@@ -146,15 +153,47 @@ const Underboard = forwardRef<UnderboardApi, UnderboardProps>(
             hiddenTabs = tabs.slice(maxTabs - 1);
         }
 
-        const [underboard, setUnderboard] = useState(
-            initialTab
-                ? initialTab
-                : isOwner
-                  ? DefaultUnderboardTab.Editor
-                  : game
-                    ? DefaultUnderboardTab.Tags
-                    : DefaultUnderboardTab.Explorer,
+        const fallbackTab = useMemo(
+            () =>
+                isOwner
+                    ? DefaultUnderboardTab.Editor
+                    : game
+                      ? DefaultUnderboardTab.Tags
+                      : DefaultUnderboardTab.Explorer,
+            [isOwner, game],
         );
+
+        const [storedTab, setStoredTab] = useLocalStorage<string>('underboardTab', fallbackTab);
+
+        // Local override for pages with forced initialTab (puzzles, exams, analysis).
+        // Allows tab switching without persisting to localStorage.
+        const [localOverride, setLocalOverride] = useState<string | null>(null);
+
+        const underboard = useMemo(() => {
+            if (localOverride) {
+                const overrideExists = tabs.some(
+                    (t) => (typeof t === 'string' ? t : t.name) === localOverride,
+                );
+                if (overrideExists) return localOverride;
+            }
+            if (initialTab) {
+                return initialTab;
+            }
+            const tabExists = tabs.some((t) => (typeof t === 'string' ? t : t.name) === storedTab);
+            return tabExists ? storedTab : fallbackTab;
+        }, [localOverride, initialTab, tabs, storedTab, fallbackTab]);
+
+        const setUnderboard = useCallback(
+            (tab: string) => {
+                if (initialTab) {
+                    setLocalOverride(tab);
+                } else {
+                    setStoredTab(tab);
+                }
+            },
+            [initialTab, setStoredTab],
+        );
+
         const light = useLightMode();
 
         useImperativeHandle(ref, () => {

--- a/frontend/src/components/profile/directories/DirectoriesSection.tsx
+++ b/frontend/src/components/profile/directories/DirectoriesSection.tsx
@@ -285,12 +285,10 @@ const DirectorySection = ({
                     columnVisibilityModel={columnVisibility}
                     onColumnVisibilityModelChange={(model) => setColumnVisibility(model)}
                     onColumnOrderChange={() => {
-                        queueMicrotask(() => {
-                            const gridColumns = apiRef.current?.getAllColumns();
-                            if (gridColumns) {
-                                setColumnOrder(gridColumns.map((col) => col.field));
-                            }
-                        });
+                        const gridColumns = apiRef.current?.getAllColumns();
+                        if (gridColumns) {
+                            setColumnOrder(gridColumns.map((col) => col.field));
+                        }
                     }}
                     density={density}
                     onDensityChange={(d) => setDensity(d)}

--- a/frontend/src/components/profile/directories/DirectoriesSection.tsx
+++ b/frontend/src/components/profile/directories/DirectoriesSection.tsx
@@ -36,6 +36,7 @@ import {
     GridToolbarContainer,
     GridToolbarDensitySelector,
     GridToolbarFilterButton,
+    useGridApiRef,
 } from '@mui/x-data-grid-pro';
 import React, { useMemo, useState } from 'react';
 import { useLocalStorage } from 'usehooks-ts';
@@ -131,6 +132,13 @@ const DirectorySection = ({
             },
         ],
     );
+
+    const [columnOrder, setColumnOrder] = useLocalStorage<string[]>(
+        `/DirectoryTable/${namespace}/columnOrder`,
+        [],
+    );
+
+    const apiRef = useGridApiRef();
 
     const directoryId = searchParams.get('directory') || 'home';
     const directoryOwner = searchParams.get('directoryOwner') || defaultDirectoryOwner;
@@ -268,6 +276,7 @@ const DirectorySection = ({
                 )}
 
                 <DataGridPro
+                    apiRef={apiRef}
                     autoHeight
                     listViewColumn={listViewColDef}
                     listView={isMobile}
@@ -275,6 +284,14 @@ const DirectorySection = ({
                     columns={isAdmin ? adminColumns : publicColumns}
                     columnVisibilityModel={columnVisibility}
                     onColumnVisibilityModelChange={(model) => setColumnVisibility(model)}
+                    onColumnOrderChange={() => {
+                        queueMicrotask(() => {
+                            const gridColumns = apiRef.current?.getAllColumns();
+                            if (gridColumns) {
+                                setColumnOrder(gridColumns.map((col) => col.field));
+                            }
+                        });
+                    }}
                     density={density}
                     onDensityChange={(d) => setDensity(d)}
                     onRowClick={onClickRow}
@@ -294,6 +311,9 @@ const DirectorySection = ({
                         density: 'standard',
                         pagination: {
                             paginationModel: { pageSize: 10 },
+                        },
+                        columns: {
+                            orderedFields: columnOrder.length > 0 ? columnOrder : undefined,
                         },
                     }}
                     sortModel={sortModel}


### PR DESCRIPTION
## Summary

Two things in the Games directory and game view didn't persist across page reloads. Now they do.

- **Column order**: Dragging columns to reorder them in the directory DataGrid now persists via localStorage, using MUI DataGrid Pro's onColumnOrderChange callback and initialState.columns.orderedFields
- **Active tab**: The selected underboard tab (Files, Edit PGN, Explorer, etc.) now persists via localStorage. Pages with a forced initial tab (puzzles, exams, analysis board) still show the correct tab but don't overwrite the user's preference for regular game pages

## Related Issues

Fixes #2133

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* [x] It was not necessary to add tests due to the changes being localStorage-backed UI state with no testable logic

Manually tested:
- [x] Column drag-and-drop reorder persists across reloads
- [x] Tab selection persists across reloads and game navigation
- [x] Forced initialTab pages (analysis board, puzzles) show correct tab, allow switching, and don't overwrite game page preference
- [x] All existing tabs tested for persistence on reload

## Demo

Screenshots to below.