### PR TITLE
feat(#2120): add linked requirement cascade for game review tier

### DIFF
--- a/backend/database/requirement.go
+++ b/backend/database/requirement.go
@@ -238,6 +238,10 @@ type Requirement struct {
 
 	// The subscription tiers that have access to this task.
 	SubscriptionTiers []SubscriptionTier `dynamodbav:"subscriptionTiers,omitempty" json:"subscriptionTiers,omitempty"`
+
+	// The ID of another requirement whose progress should be incremented
+	// when this requirement's progress is updated (one-way cascade).
+	LinkedRequirementId string `dynamodbav:"linkedRequirementId,omitempty" json:"linkedRequirementId,omitempty"`
 }
 
 func (r *Requirement) clampCount(cohort DojoCohort, count int) int {

--- a/backend/user/progress/update/main.go
+++ b/backend/user/progress/update/main.go
@@ -249,7 +249,7 @@ func cascadeLinkedProgress(request *ProgressUpdateRequest, user *database.User, 
 	}
 
 	delta := request.NewCount - request.PreviousCount
-	if delta <= 0 {
+	if delta <= 0 && request.IncrementalMinutesSpent <= 0 {
 		return user
 	}
 
@@ -279,11 +279,17 @@ func cascadeLinkedProgress(request *ProgressUpdateRequest, user *database.User, 
 		linkedProgress.MinutesSpent = make(map[database.DojoCohort]int)
 	}
 
-	maxCount := linkedReq.Counts[request.Cohort]
-	if linkedReq.NumberOfCohorts == 1 || linkedReq.NumberOfCohorts == 0 {
-		linkedProgress.Counts[database.AllCohorts] = min(linkedProgress.Counts[database.AllCohorts]+delta, maxCount)
-	} else {
-		linkedProgress.Counts[request.Cohort] = min(linkedProgress.Counts[request.Cohort]+delta, maxCount)
+	if delta > 0 {
+		maxCount := linkedReq.Counts[request.Cohort]
+		if linkedReq.NumberOfCohorts == 1 || linkedReq.NumberOfCohorts == 0 {
+			linkedProgress.Counts[database.AllCohorts] = min(linkedProgress.Counts[database.AllCohorts]+delta, maxCount)
+		} else {
+			linkedProgress.Counts[request.Cohort] = min(linkedProgress.Counts[request.Cohort]+delta, maxCount)
+		}
+	}
+
+	if request.IncrementalMinutesSpent > 0 {
+		linkedProgress.MinutesSpent[request.Cohort] += request.IncrementalMinutesSpent
 	}
 
 	linkedProgress.UpdatedAt = time.Now().Format(time.RFC3339)

--- a/backend/user/progress/update/main.go
+++ b/backend/user/progress/update/main.go
@@ -264,6 +264,9 @@ func cascadeLinkedProgress(request *ProgressUpdateRequest, user *database.User, 
 		return user
 	}
 
+	if user.Progress == nil {
+		user.Progress = make(map[string]*database.RequirementProgress)
+	}
 	linkedProgress, ok := user.Progress[req.LinkedRequirementId]
 	if !ok {
 		linkedProgress = &database.RequirementProgress{

--- a/backend/user/progress/update/main.go
+++ b/backend/user/progress/update/main.go
@@ -178,6 +178,7 @@ func handleTask(event api.Request, request *ProgressUpdateRequest, user *databas
 		return api.Failure(err), nil
 	}
 
+	user = cascadeLinkedProgress(request, user, task)
 	milestone.checkNotification(user)
 
 	return api.Success(ProgressUpdateResponse{User: user, TimelineEntry: timelineEntry}), nil
@@ -233,4 +234,65 @@ func (mc *milestoneChecker) fetchAllRequirements(cohort database.DojoCohort) ([]
 		startKey = nextKey
 	}
 	return requirements, nil
+}
+
+// cascadeLinkedProgress updates the linked requirement's progress when the
+// source requirement has a LinkedRequirementId set. This is a one-way cascade:
+// incrementing the source also increments the linked target by the same delta.
+// No timeline entry is written for the linked requirement; only the raw
+// progress count and minutes are updated.
+// Errors are logged but do not block the primary update.
+func cascadeLinkedProgress(request *ProgressUpdateRequest, user *database.User, task database.Task) *database.User {
+	req, ok := task.(*database.Requirement)
+	if !ok || req.LinkedRequirementId == "" {
+		return user
+	}
+
+	delta := request.NewCount - request.PreviousCount
+	if delta <= 0 {
+		return user
+	}
+
+	linkedReq, err := repository.GetRequirement(req.LinkedRequirementId)
+	if err != nil {
+		log.Errorf("Cascade: failed to get linked requirement %s for user %s (source: %s): %v", req.LinkedRequirementId, user.Username, req.Id, err)
+		return user
+	}
+
+	if _, ok := linkedReq.Counts[request.Cohort]; !ok {
+		log.Infof("Cascade: cohort %s not in linked requirement %s counts, skipping", request.Cohort, req.LinkedRequirementId)
+		return user
+	}
+
+	linkedProgress, ok := user.Progress[req.LinkedRequirementId]
+	if !ok {
+		linkedProgress = &database.RequirementProgress{
+			RequirementId: req.LinkedRequirementId,
+			Counts:        make(map[database.DojoCohort]int),
+			MinutesSpent:  make(map[database.DojoCohort]int),
+		}
+	}
+	if linkedProgress.Counts == nil {
+		linkedProgress.Counts = make(map[database.DojoCohort]int)
+	}
+	if linkedProgress.MinutesSpent == nil {
+		linkedProgress.MinutesSpent = make(map[database.DojoCohort]int)
+	}
+
+	maxCount := linkedReq.Counts[request.Cohort]
+	if linkedReq.NumberOfCohorts == 1 || linkedReq.NumberOfCohorts == 0 {
+		linkedProgress.Counts[database.AllCohorts] = min(linkedProgress.Counts[database.AllCohorts]+delta, maxCount)
+	} else {
+		linkedProgress.Counts[request.Cohort] = min(linkedProgress.Counts[request.Cohort]+delta, maxCount)
+	}
+
+	linkedProgress.UpdatedAt = time.Now().Format(time.RFC3339)
+
+	updatedUser, err := repository.UpdateUserProgress(user.Username, linkedProgress)
+	if err != nil {
+		log.Errorf("Cascade: failed to update linked progress for user %s, requirement %s: %v", user.Username, req.LinkedRequirementId, err)
+		return user
+	}
+
+	return updatedUser
 }

--- a/backend/user/progress/update/main_test.go
+++ b/backend/user/progress/update/main_test.go
@@ -419,7 +419,7 @@ func (m *mockRepository) GetRequirement(id string) (*database.Requirement, error
 func (m *mockRepository) UpdateUserProgress(username string, progress *database.RequirementProgress) (*database.User, error) {
 	m.capturedProgress = append(m.capturedProgress, progress)
 	if m.updateProgressErr != nil {
-		return m.user, m.updateProgressErr
+		return nil, m.updateProgressErr
 	}
 	return m.user, nil
 }
@@ -450,9 +450,6 @@ func (m *mockRepository) DeleteTimelineEntries(entries []*database.TimelineEntry
 func (m *mockRepository) AddSentMilestoneNotification(username string, milestoneKey string) error {
 	return nil
 }
-
-var _ = fmt.Errorf
-var _ = testing.T{}
 
 func newTestUser() *database.User {
 	return &database.User{

--- a/backend/user/progress/update/main_test.go
+++ b/backend/user/progress/update/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
@@ -394,4 +395,205 @@ func TestCheckNotification_RecordMilestoneError_DoesNotPanic(t *testing.T) {
 	}
 
 	mc.checkNotification(user)
+}
+
+type mockRepository struct {
+	user              *database.User
+	requirement       *database.Requirement
+	getRequirementErr error
+	updateProgressErr error
+	capturedProgress  []*database.RequirementProgress
+}
+
+func (m *mockRepository) GetUser(username string) (*database.User, error) {
+	return m.user, nil
+}
+
+func (m *mockRepository) GetRequirement(id string) (*database.Requirement, error) {
+	if m.getRequirementErr != nil {
+		return nil, m.getRequirementErr
+	}
+	return m.requirement, nil
+}
+
+func (m *mockRepository) UpdateUserProgress(username string, progress *database.RequirementProgress) (*database.User, error) {
+	m.capturedProgress = append(m.capturedProgress, progress)
+	if m.updateProgressErr != nil {
+		return m.user, m.updateProgressErr
+	}
+	return m.user, nil
+}
+
+func (m *mockRepository) PutTimelineEntry(entry *database.TimelineEntry) error {
+	return nil
+}
+
+// Stubs to satisfy UserProgressUpdater interface
+func (m *mockRepository) UpdateUser(username string, update *database.UserUpdate) (*database.User, error) {
+	return m.user, nil
+}
+func (m *mockRepository) RecordSubscriptionCancelation(cohort database.DojoCohort) error {
+	return nil
+}
+func (m *mockRepository) RecordFreeTierConversion(cohort database.DojoCohort) error {
+	return nil
+}
+func (m *mockRepository) ListTimelineEntries(owner string, startKey string) ([]*database.TimelineEntry, string, error) {
+	return nil, "", nil
+}
+func (m *mockRepository) PutTimelineEntries(entries []*database.TimelineEntry) (int, error) {
+	return 0, nil
+}
+func (m *mockRepository) DeleteTimelineEntries(entries []*database.TimelineEntry) (int, error) {
+	return 0, nil
+}
+func (m *mockRepository) AddSentMilestoneNotification(username string, milestoneKey string) error {
+	return nil
+}
+
+var _ = fmt.Errorf
+var _ = testing.T{}
+
+func newTestUser() *database.User {
+	return &database.User{
+		Username:    "test-user",
+		DisplayName: "Test User",
+		Progress:    make(map[string]*database.RequirementProgress),
+	}
+}
+
+func TestCascadeLinkedProgress_HappyPath(t *testing.T) {
+	linkedReq := &database.Requirement{
+		Id:              "linked-req-id",
+		Counts:          map[database.DojoCohort]int{"1400-1500": 14},
+		NumberOfCohorts: -1,
+	}
+	sourceReq := &database.Requirement{
+		LinkedRequirementId: "linked-req-id",
+	}
+	user := newTestUser()
+	mock := &mockRepository{user: user, requirement: linkedReq}
+	repository = mock
+
+	request := &ProgressUpdateRequest{Cohort: "1400-1500", PreviousCount: 2, NewCount: 3}
+	result := cascadeLinkedProgress(request, user, sourceReq)
+
+	if len(mock.capturedProgress) != 1 {
+		t.Fatalf("expected 1 UpdateUserProgress call, got %d", len(mock.capturedProgress))
+	}
+	captured := mock.capturedProgress[0]
+	if captured.RequirementId != "linked-req-id" {
+		t.Errorf("expected requirementId linked-req-id, got %s", captured.RequirementId)
+	}
+	if captured.Counts["1400-1500"] != 1 {
+		t.Errorf("expected count 1, got %d", captured.Counts["1400-1500"])
+	}
+	if result != user {
+		t.Error("expected updated user to be returned")
+	}
+}
+
+func TestCascadeLinkedProgress_SkipsWhenNoLinkedId(t *testing.T) {
+	sourceReq := &database.Requirement{LinkedRequirementId: ""}
+	user := newTestUser()
+	mock := &mockRepository{user: user}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 0, NewCount: 1}
+	cascadeLinkedProgress(request, user, sourceReq)
+	if len(mock.capturedProgress) != 0 {
+		t.Errorf("expected no UpdateUserProgress calls, got %d", len(mock.capturedProgress))
+	}
+}
+
+func TestCascadeLinkedProgress_SkipsWhenDeltaZero(t *testing.T) {
+	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
+	user := newTestUser()
+	mock := &mockRepository{user: user}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 3, NewCount: 3}
+	cascadeLinkedProgress(request, user, sourceReq)
+	if len(mock.capturedProgress) != 0 {
+		t.Errorf("expected no calls, got %d", len(mock.capturedProgress))
+	}
+}
+
+func TestCascadeLinkedProgress_SkipsWhenDeltaNegative(t *testing.T) {
+	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
+	user := newTestUser()
+	mock := &mockRepository{user: user}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 5, NewCount: 3}
+	cascadeLinkedProgress(request, user, sourceReq)
+	if len(mock.capturedProgress) != 0 {
+		t.Errorf("expected no calls, got %d", len(mock.capturedProgress))
+	}
+}
+
+func TestCascadeLinkedProgress_SkipsForCustomTask(t *testing.T) {
+	customTask := &database.CustomTask{Id: "custom-task-id"}
+	user := newTestUser()
+	mock := &mockRepository{user: user}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 0, NewCount: 1}
+	cascadeLinkedProgress(request, user, customTask)
+	if len(mock.capturedProgress) != 0 {
+		t.Errorf("expected no calls, got %d", len(mock.capturedProgress))
+	}
+}
+
+func TestCascadeLinkedProgress_SkipsWhenLinkedReqNotFound(t *testing.T) {
+	sourceReq := &database.Requirement{LinkedRequirementId: "missing-req"}
+	user := newTestUser()
+	mock := &mockRepository{user: user, getRequirementErr: fmt.Errorf("not found")}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 0, NewCount: 1, Cohort: "1400-1500"}
+	result := cascadeLinkedProgress(request, user, sourceReq)
+	if result != user {
+		t.Error("expected original user on error")
+	}
+	if len(mock.capturedProgress) != 0 {
+		t.Errorf("expected no calls, got %d", len(mock.capturedProgress))
+	}
+}
+
+func TestCascadeLinkedProgress_SkipsWhenCohortNotInLinkedReq(t *testing.T) {
+	linkedReq := &database.Requirement{Id: "linked-req-id", Counts: map[database.DojoCohort]int{"1800-1900": 7}}
+	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
+	user := newTestUser()
+	mock := &mockRepository{user: user, requirement: linkedReq}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 0, NewCount: 1, Cohort: "1400-1500"}
+	cascadeLinkedProgress(request, user, sourceReq)
+	if len(mock.capturedProgress) != 0 {
+		t.Errorf("expected no calls, got %d", len(mock.capturedProgress))
+	}
+}
+
+func TestCascadeLinkedProgress_UsesAllCohortsKey(t *testing.T) {
+	linkedReq := &database.Requirement{Id: "linked-req-id", Counts: map[database.DojoCohort]int{"1400-1500": 14}, NumberOfCohorts: 1}
+	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
+	user := newTestUser()
+	mock := &mockRepository{user: user, requirement: linkedReq}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 0, NewCount: 2, Cohort: "1400-1500"}
+	cascadeLinkedProgress(request, user, sourceReq)
+	if len(mock.capturedProgress) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(mock.capturedProgress))
+	}
+	if mock.capturedProgress[0].Counts[database.AllCohorts] != 2 {
+		t.Errorf("expected AllCohorts count 2, got %d", mock.capturedProgress[0].Counts[database.AllCohorts])
+	}
+}
+
+func TestCascadeLinkedProgress_ReturnsOriginalUserOnUpdateFailure(t *testing.T) {
+	linkedReq := &database.Requirement{Id: "linked-req-id", Counts: map[database.DojoCohort]int{"1400-1500": 14}, NumberOfCohorts: -1}
+	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
+	user := newTestUser()
+	mock := &mockRepository{user: user, requirement: linkedReq, updateProgressErr: fmt.Errorf("dynamodb error")}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 0, NewCount: 1, Cohort: "1400-1500"}
+	result := cascadeLinkedProgress(request, user, sourceReq)
+	if result != user {
+		t.Error("expected original user on cascade failure")
+	}
 }

--- a/backend/user/progress/update/main_test.go
+++ b/backend/user/progress/update/main_test.go
@@ -475,7 +475,7 @@ func TestCascadeLinkedProgress_HappyPath(t *testing.T) {
 	mock := &mockRepository{user: user, requirement: linkedReq}
 	repository = mock
 
-	request := &ProgressUpdateRequest{Cohort: "1400-1500", PreviousCount: 2, NewCount: 3}
+	request := &ProgressUpdateRequest{Cohort: "1400-1500", PreviousCount: 2, NewCount: 3, IncrementalMinutesSpent: 60}
 	result := cascadeLinkedProgress(request, user, sourceReq)
 
 	if len(mock.capturedProgress) != 1 {
@@ -487,6 +487,9 @@ func TestCascadeLinkedProgress_HappyPath(t *testing.T) {
 	}
 	if captured.Counts["1400-1500"] != 1 {
 		t.Errorf("expected count 1, got %d", captured.Counts["1400-1500"])
+	}
+	if captured.MinutesSpent["1400-1500"] != 60 {
+		t.Errorf("expected 60 minutes, got %d", captured.MinutesSpent["1400-1500"])
 	}
 	if result != user {
 		t.Error("expected updated user to be returned")
@@ -505,27 +508,47 @@ func TestCascadeLinkedProgress_SkipsWhenNoLinkedId(t *testing.T) {
 	}
 }
 
-func TestCascadeLinkedProgress_SkipsWhenDeltaZero(t *testing.T) {
+func TestCascadeLinkedProgress_SkipsWhenNoDeltaAndNoMinutes(t *testing.T) {
 	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
 	user := newTestUser()
 	mock := &mockRepository{user: user}
 	repository = mock
-	request := &ProgressUpdateRequest{PreviousCount: 3, NewCount: 3}
+	request := &ProgressUpdateRequest{PreviousCount: 3, NewCount: 3, IncrementalMinutesSpent: 0}
 	cascadeLinkedProgress(request, user, sourceReq)
 	if len(mock.capturedProgress) != 0 {
 		t.Errorf("expected no calls, got %d", len(mock.capturedProgress))
 	}
 }
 
-func TestCascadeLinkedProgress_SkipsWhenDeltaNegative(t *testing.T) {
+func TestCascadeLinkedProgress_SkipsWhenDeltaNegativeAndNoMinutes(t *testing.T) {
 	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
 	user := newTestUser()
 	mock := &mockRepository{user: user}
 	repository = mock
-	request := &ProgressUpdateRequest{PreviousCount: 5, NewCount: 3}
+	request := &ProgressUpdateRequest{PreviousCount: 5, NewCount: 3, IncrementalMinutesSpent: 0}
 	cascadeLinkedProgress(request, user, sourceReq)
 	if len(mock.capturedProgress) != 0 {
 		t.Errorf("expected no calls, got %d", len(mock.capturedProgress))
+	}
+}
+
+func TestCascadeLinkedProgress_CascadesTimeOnlyWhenNoGameCount(t *testing.T) {
+	linkedReq := &database.Requirement{Id: "linked-req-id", Counts: map[database.DojoCohort]int{"1400-1500": 14}, NumberOfCohorts: -1}
+	sourceReq := &database.Requirement{LinkedRequirementId: "linked-req-id"}
+	user := newTestUser()
+	mock := &mockRepository{user: user, requirement: linkedReq}
+	repository = mock
+	request := &ProgressUpdateRequest{PreviousCount: 3, NewCount: 3, Cohort: "1400-1500", IncrementalMinutesSpent: 60}
+	cascadeLinkedProgress(request, user, sourceReq)
+	if len(mock.capturedProgress) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(mock.capturedProgress))
+	}
+	captured := mock.capturedProgress[0]
+	if captured.MinutesSpent["1400-1500"] != 60 {
+		t.Errorf("expected 60 minutes, got %d", captured.MinutesSpent["1400-1500"])
+	}
+	if captured.Counts["1400-1500"] != 0 {
+		t.Errorf("expected 0 count, got %d", captured.Counts["1400-1500"])
 	}
 }
 

--- a/frontend/src/components/profile/trainingPlan/ProgressUpdater.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressUpdater.tsx
@@ -70,9 +70,7 @@ export const ProgressUpdater = ({
         timerMinutes = 0;
     }
     const hasLinkedReq = isRequirement(requirement) && !!requirement.linkedRequirementId;
-    const [hours, setHours] = useState(
-        timerHours ? `${timerHours}` : hasLinkedReq ? '1' : '',
-    );
+    const [hours, setHours] = useState(timerHours ? `${timerHours}` : hasLinkedReq ? '1' : '');
     const [minutes, setMinutes] = useState(timerMinutes ? `${timerMinutes}` : '');
 
     const [errors, setErrors] = useState<Record<string, string>>({});

--- a/frontend/src/components/profile/trainingPlan/ProgressUpdater.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressUpdater.tsx
@@ -69,7 +69,10 @@ export const ProgressUpdater = ({
         timerHours = 0;
         timerMinutes = 0;
     }
-    const [hours, setHours] = useState(timerHours ? `${timerHours}` : '');
+    const hasLinkedReq = isRequirement(requirement) && !!requirement.linkedRequirementId;
+    const [hours, setHours] = useState(
+        timerHours ? `${timerHours}` : hasLinkedReq ? '1' : '',
+    );
     const [minutes, setMinutes] = useState(timerMinutes ? `${timerMinutes}` : '');
 
     const [errors, setErrors] = useState<Record<string, string>>({});

--- a/frontend/src/components/profile/trainingPlan/ProgressUpdater.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressUpdater.tsx
@@ -70,7 +70,9 @@ export const ProgressUpdater = ({
         timerMinutes = 0;
     }
     const hasLinkedReq = isRequirement(requirement) && !!requirement.linkedRequirementId;
-    const [hours, setHours] = useState(timerHours ? `${timerHours}` : hasLinkedReq ? '1' : '');
+    const [hours, setHours] = useState(
+        timerHours ? `${timerHours}` : !timerSeconds && hasLinkedReq ? '1' : '',
+    );
     const [minutes, setMinutes] = useState(timerMinutes ? `${timerMinutes}` : '');
 
     const [errors, setErrors] = useState<Record<string, string>>({});

--- a/frontend/src/database/requirement.ts
+++ b/frontend/src/database/requirement.ts
@@ -164,6 +164,12 @@ export interface Requirement {
 
     /** The subscription tiers that can view this requirement. */
     subscriptionTiers?: SubscriptionTier[];
+
+    /**
+     * The ID of another requirement whose progress is incremented
+     * when this requirement's progress is updated (one-way cascade).
+     */
+    linkedRequirementId?: string;
 }
 
 /**

--- a/scripts/create_game_review_requirements.py
+++ b/scripts/create_game_review_requirements.py
@@ -15,11 +15,15 @@ Before running, fill in:
 """
 
 import argparse
+import re
 import sys
 from datetime import datetime, timezone
 
 import boto3
 
+UUID_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+)
 
 # -- Deterministic IDs for idempotency (re-running overwrites, not duplicates) --
 PEER_REVIEW_REQ_ID = "a1b2c3d4-peer-review-session-placeholder"
@@ -39,8 +43,14 @@ COUNTS = {
 def validate():
     """Check that all placeholder values have been filled in before writing."""
     errors = []
-    if "TODO" in EQUAL_RATED_REQ_ID:
-        errors.append("EQUAL_RATED_REQ_ID still contains placeholder 'TODO'")
+    for name, val in [
+        ("PEER_REVIEW_REQ_ID", PEER_REVIEW_REQ_ID),
+        ("SENSEI_REVIEW_REQ_ID", SENSEI_REVIEW_REQ_ID),
+        ("EQUAL_RATED_REQ_ID", EQUAL_RATED_REQ_ID),
+        ("HIGHER_RATED_REQ_ID", HIGHER_RATED_REQ_ID),
+    ]:
+        if not UUID_PATTERN.match(val):
+            errors.append(f"{name} is not a valid UUID: {val}")
     if not COUNTS:
         errors.append("COUNTS dict is empty — no cohort targets defined")
     if errors:

--- a/scripts/create_game_review_requirements.py
+++ b/scripts/create_game_review_requirements.py
@@ -1,0 +1,129 @@
+"""
+Seed the two new Game Review requirements into DynamoDB.
+
+Usage:
+    python scripts/create_game_review_requirements.py --stage dev
+    python scripts/create_game_review_requirements.py --stage prod
+
+Requires:
+    - AWS credentials with DynamoDB write access
+    - boto3: pip install boto3
+
+Before running, fill in:
+    - EQUAL_RATED_REQ_ID: look up "Review Games with Equal-Rated Players" in DynamoDB
+    - COUNTS: per-cohort target counts (ask maintainer)
+"""
+
+import argparse
+import sys
+from datetime import datetime, timezone
+
+import boto3
+
+
+# -- Deterministic IDs for idempotency (re-running overwrites, not duplicates) --
+PEER_REVIEW_REQ_ID = "a1b2c3d4-peer-review-session-placeholder"
+SENSEI_REVIEW_REQ_ID = "a1b2c3d4-sensei-review-session-placeholder"
+
+# -- IDs of existing requirements that the new ones cascade to --
+HIGHER_RATED_REQ_ID = "72241c06-5d06-4245-92da-9b294c6b736a"
+EQUAL_RATED_REQ_ID = "TODO_LOOK_UP_FROM_DYNAMODB"
+
+# -- Per-cohort target counts (placeholder — ask maintainer) --
+COUNTS = {
+    # "0-300": 0,
+    # "300-400": 0,
+    # ...fill in from existing review requirements or maintainer input
+}
+
+def validate():
+    """Check that all placeholder values have been filled in before writing."""
+    errors = []
+    if "TODO" in EQUAL_RATED_REQ_ID:
+        errors.append("EQUAL_RATED_REQ_ID still contains placeholder 'TODO'")
+    if not COUNTS:
+        errors.append("COUNTS dict is empty — no cohort targets defined")
+    if errors:
+        print("ERROR: Cannot run script with incomplete configuration:")
+        for e in errors:
+            print(f"  - {e}")
+        sys.exit(1)
+
+
+REQUIREMENTS = [
+    {
+        "id": {"S": PEER_REVIEW_REQ_ID},
+        "status": {"S": "ACTIVE"},
+        "category": {"S": "Games + Analysis"},
+        "name": {"S": "Peer Review Session"},
+        "description": {"S": ""},
+        "freeDescription": {"S": ""},
+        "counts": {"M": {k: {"N": str(v)} for k, v in COUNTS.items()}},
+        "startCount": {"N": "0"},
+        "numberOfCohorts": {"N": "-1"},
+        "unitScore": {"N": "0"},
+        "totalScore": {"N": "0"},
+        "scoreboardDisplay": {"S": "PROGRESS_BAR"},
+        "progressBarSuffix": {"S": ""},
+        "sortPriority": {"S": ""},
+        "expirationDays": {"N": "-1"},
+        "isFree": {"BOOL": False},
+        "subscriptionTiers": {"L": [{"S": "GAME_REVIEW"}]},
+        "linkedRequirementId": {"S": EQUAL_RATED_REQ_ID},
+        "updatedAt": {"S": ""},
+    },
+    {
+        "id": {"S": SENSEI_REVIEW_REQ_ID},
+        "status": {"S": "ACTIVE"},
+        "category": {"S": "Games + Analysis"},
+        "name": {"S": "Review with Sensei"},
+        "description": {"S": ""},
+        "freeDescription": {"S": ""},
+        "counts": {"M": {k: {"N": str(v)} for k, v in COUNTS.items()}},
+        "startCount": {"N": "0"},
+        "numberOfCohorts": {"N": "-1"},
+        "unitScore": {"N": "0"},
+        "totalScore": {"N": "0"},
+        "scoreboardDisplay": {"S": "PROGRESS_BAR"},
+        "progressBarSuffix": {"S": ""},
+        "sortPriority": {"S": ""},
+        "expirationDays": {"N": "-1"},
+        "isFree": {"BOOL": False},
+        "subscriptionTiers": {"L": [{"S": "GAME_REVIEW"}]},
+        "linkedRequirementId": {"S": HIGHER_RATED_REQ_ID},
+        "updatedAt": {"S": ""},
+    },
+]
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stage", required=True, choices=["dev", "prod"])
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print items without writing"
+    )
+    args = parser.parse_args()
+
+    validate()
+
+    table_name = f"{args.stage}-requirements"
+    client = boto3.client("dynamodb", region_name="us-east-1")
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    for req in REQUIREMENTS:
+        req["updatedAt"]["S"] = now
+        if args.dry_run:
+            print(f"Would write: {req['name']['S']} ({req['id']['S']})")
+            continue
+
+        try:
+            client.put_item(TableName=table_name, Item=req)
+            print(f"Created: {req['name']['S']} ({req['id']['S']})")
+        except Exception as e:
+            print(f"FAILED to write {req['name']['S']}: {e}")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add one-way progress cascade for game review tier requirements. When a user updates "Peer Review Session", the system also increments "Review with Equal-Rated Players". Same for "Review with Sensei" and "Review with Higher-Rated Players". Cascade is silent (no timeline entry), clamped to target count, and errors are logged without blocking the primary update.

When updating these requirements, the time field defaults to 1 hour (adjustable by the user).

Includes a DynamoDB seeding script that needs maintainer input before running (cohort counts, descriptions, equal-rated requirement ID).

## Related Issues

Fixes #2120

## Type of change

* [x] New feature (non-breaking change which adds functionality)

## Testing

* [x] New unit tests (vitest) were added

Backend: 9 unit tests covering cascade happy path, skip conditions (no linked ID, delta <= 0, custom task, cohort mismatch), and error handling (linked req not found, update failure).

## TODO for dev testing

- [ ] Run seeding script with correct values (EQUAL_RATED_REQ_ID, per-cohort counts, descriptions, sortPriority)
- [ ] Verify "Peer Review Session" and "Review with Sensei" only appear for GAME_REVIEW tier users
- [ ] Verify requirements are hidden from Free/Basic/Lecture tier users
- [ ] Update "Peer Review Session" by +1, confirm "Review with Equal-Rated Players" also increments by 1
- [ ] Update "Review with Sensei" by +1, confirm "Review with Higher-Rated Players" also increments by 1
- [ ] Confirm cascade count doesn't exceed the linked requirement's target count
- [ ] Confirm updating the linked requirement directly does NOT cascade back
- [ ] Confirm the 1-hour default shows in the time field when updating peer/sensei requirements
- [ ] Confirm timer still takes priority over the 1-hour default if running

## Demo

No frontend UI changes.