### PR TITLE
feat(#1997): extract remaining customer-facing strings to next-intl

### DIFF
--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -2,7 +2,10 @@
     "common": {
         "timezone": "Timezone",
         "language": "Language",
-        "browserDefault": "Browser Default ({offset})"
+        "browserDefault": "Browser Default ({offset})",
+        "timeMinutes": "{minutes}m",
+        "timeHours": "{hours}h",
+        "timeHoursMinutes": "{hours}h {minutes}m"
     },
     "profile": {
         "editor": {
@@ -144,7 +147,9 @@
                 "Wed": "Wed",
                 "Thur": "Thur",
                 "Fri": "Fri",
-                "Sat": "Sat"
+                "Sat": "Sat",
+                "activeOnlyTooltip": "Only show tasks you have updated this week",
+                "activeOnlyLabel": "Active Only"
             },
             "full": {
                 "heading": "Full Training Plan",
@@ -164,7 +169,11 @@
                 "renewTooltip": "It's time for you to renew this task!",
                 "renewLabel": "Renew",
                 "minimumReachedTooltip": "You've reached the minimum, keep going!",
-                "minimumReachedLabel": "Minimum Reached"
+                "minimumReachedLabel": "Minimum Reached",
+                "checkboxAriaLabel": "Checkbox {name}",
+                "updateAriaLabel": "Update {name}",
+                "graduateName": "Graduate from {cohort}",
+                "graduateDescription": "Move to the next cohort and get featured in the graduation show."
             },
             "graduation": {
                 "title": "Graduate from {cohort}?",
@@ -254,7 +263,8 @@
                 "cohort": "Cohort",
                 "deleteEntry": "Delete entry",
                 "totalCount": "Total {label} : {total}. Current Cohort: {cohortCount}",
-                "totalTime": "Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m"
+                "totalTime": "Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
+                "deleteAriaLabel": "delete"
             },
             "progressUpdater": {
                 "markComplete": "Mark as Completed?",
@@ -365,7 +375,8 @@
             "save": "Save",
             "updateTitle": "Update {name}?",
             "totalCount": "Total Count: {totalCount}. Current Cohort: {cohortCount}",
-            "totalTime": "Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m"
+            "totalTime": "Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
+            "restDayCleared": "Rest day cleared"
         },
         "info": {
             "type": "Type",
@@ -841,14 +852,31 @@
         "clearAll": "Clear All",
         "empty": "No notifications",
         "view": "View",
-        "delete": "Delete notification"
+        "delete": "Delete notification",
+        "newFollowerTitle": "You have a new follower",
+        "explorerGameTitle": "{count} new games were added with a position you follow.",
+        "calendarInviteTitle": "You've been invited to an event on the calendar",
+        "roundRobinStartTitle": "Round robin {cohort} {name} has started",
+        "gameCommentDescription": "There are new comments on your game.",
+        "gameCommentReplyDescription": "{count, plural, =1 {There is a new reply to a comment thread you participated in.} other {There are # new replies in comment threads you participated in.}}",
+        "gameReviewCompleteDescription": "{reviewer} reviewed your game. Check the game settings for more info.",
+        "timelineCommentDescription": "{count, plural, =1 {There is a new comment on your activity.} other {There are # new comments on your activity.}}",
+        "timelineReactionDescription": "{count, plural, =1 {There is a new reaction on your activity.} other {There are # new reactions on your activity.}}",
+        "explorerGameDescription": "A new game was added containing a position you follow.",
+        "clubJoinRequestDescription": "{count, plural, =1 {There is a new request to join your club.} other {There are # new requests to join your club.}}",
+        "clubJoinApprovedDescription": "Your request to join the club was approved.",
+        "calendarInviteDescription": "{owner} invited you to an event at {date} {time}"
     },
     "timer": {
         "title": "Timer",
         "workTimer": "Work Timer",
         "pause": "Pause",
         "start": "Start",
-        "reset": "Reset"
+        "reset": "Reset",
+        "pauseTimer": "Pause Timer ({time})",
+        "resumeTimer": "Resume Timer ({time})",
+        "startTimer": "Start Timer",
+        "clearAndRestart": "Clear and Restart Timer"
     },
     "navbar": {
         "searchUsers": "Search Users",
@@ -1581,7 +1609,29 @@
         "colorYoutube": "Youtube",
         "eventNotFoundError": "This event cannot be found. It is either fully booked, deleted or not available to your cohort.",
         "participantPaymentWarningOther": "This user has not paid and will lose their booking in <30 min",
-        "participantPaymentWarningSelf": "You have not completed payment and will lose your booking soon"
+        "participantPaymentWarningSelf": "You have not completed payment and will lose your booking soon",
+        "meetingTitle": "Meeting",
+        "groupMeetingTitle": "Group Meeting ({count}/{max})",
+        "available1on1Title": "Available - 1 on 1",
+        "availableGroupTitle": "Available - Group",
+        "bookableGroupTitle": "Bookable - Group ({count}/{max})",
+        "bookableTitle": "Bookable - {name}",
+        "meetingCanceled": "Meeting canceled",
+        "availabilityDeleted": "Availability deleted",
+        "hideFilters": "Hide Filters",
+        "showFilters": "Show Filters",
+        "validationRequired": "This field is required",
+        "validationStartInvalid": "Start time must be a valid time",
+        "validationEndInvalid": "End time must be a valid time",
+        "validationEndTooEarly": "End time must be at least one hour after start time",
+        "validationIntegerRequired": "You must specify an integer greater than 0",
+        "validationNumberRequired": "You must specify a number",
+        "validationDollarAmount": "You must specify a valid dollar amount with up to 2 decimal places",
+        "validationMinPrice": "Price must be at least $5",
+        "validationTypeRequired": "At least one type is required",
+        "validationCohortRequired": "At least one cohort is required",
+        "validationInviteRequired": "At least one user is required when the event is invite-only",
+        "validationCountPositive": "Must be greater than 0"
     },
     "meeting": {
         "title": "Meetings",
@@ -1699,7 +1749,8 @@
             "nullMoves": "Null Moves",
             "tags": "Tags",
             "clockTimes": "Clock Times",
-            "cancel": "Cancel"
+            "cancel": "Cancel",
+            "requestTimedOut": "Request timed out"
         },
         "visibilityDialog": {
             "unlistTitle": "{count, plural, =1 {Unlist Game?} other {Unlist {count} Games?}}",
@@ -2002,7 +2053,9 @@
             "gamePage": {
                 "preflightHint": "You can fill this data out now or later in settings."
             }
-        }
+        },
+        "reviewTypeQuick": "Quick",
+        "reviewTypeDeepDive": "Deep Dive"
     },
     "courses": {
         "filters": {
@@ -2171,7 +2224,12 @@
                 "columnRating": "Rating"
             },
             "pairings": {
-                "noOpponent": "No Opponent"
+                "noOpponent": "No Opponent",
+                "headerWhite": "White",
+                "headerBlack": "Black",
+                "headerResult": "Result",
+                "headerGame": "Game",
+                "unverifiedResultTooltip": "This result has not been verified and may be changed later by the TD"
             },
             "info": {
                 "title": "ChessDojo Open Classical",
@@ -2283,7 +2341,8 @@
             "tabs": {
                 "info": "Info",
                 "tournaments": "Tournaments",
-                "history": "History"
+                "history": "History",
+                "tabsAriaLabel": "tournament viewer tabs"
             },
             "activity": {
                 "noGamesSubmitted": "No games submitted yet",
@@ -2482,7 +2541,9 @@
                 "daysUnit": "{days, plural, =1 {# day} other {# days}}",
                 "hoursUnit": "{hours, plural, =1 {# hour} other {# hours}}",
                 "minutesUnit": "{minutes, plural, =1 {# minute} other {# minutes}}",
-                "lessThanMinute": "less than a minute"
+                "lessThanMinute": "less than a minute",
+                "viewModeAriaLabel": "view mode toggle",
+                "displayModeAriaLabel": "display mode toggle"
             }
         }
     },
@@ -2840,7 +2901,8 @@
                 "tableHeaderCohort": "Dojo Cohort",
                 "tableHeaderChesscom": "Chess.com Bot",
                 "tableHeaderLichess": "Lichess Bot"
-            }
+            },
+            "iframeTitle": "Dojo Guide To Bots"
         },
         "liveClasses": {
             "title": "Live Class Recordings",
@@ -2968,6 +3030,22 @@
             "puzzleRating": "Puzzle Rating",
             "yourRating": "Your Rating",
             "startRating": "Start Rating"
+        },
+        "hintSection": {
+            "yourTurn": "Your turn",
+            "recallMove": "Recall the move for {color}.",
+            "findBestMove": "Find the best move for {color}.",
+            "whatDidPlay": "What did {color} play in this position?",
+            "whatWouldYouPlay": "What would you play in this position?",
+            "incorrectRetry": "Incorrect, please try again.",
+            "retry": "Retry",
+            "enterHint": "(Enter)",
+            "goodMove": "Good move!",
+            "next": "Next",
+            "memorizeComplete": "Great job memorizing this game!",
+            "puzzleComplete": "Great job completing this puzzle",
+            "restart": "Restart",
+            "nextPuzzle": "Next Puzzle"
         }
     },
     "exams": {
@@ -3086,7 +3164,10 @@
             "tooltipScoreRatingNewline": "Score: {x},\nRating: {y}",
             "xAxisLabel": "Score",
             "yAxisLabel": "Normalized Rating"
-        }
+        },
+        "tacticsTest": "Tactics Test",
+        "checkmateTest": "Checkmate Test",
+        "endgameTest": "Endgame Test"
     },
     "donate": {
         "title": "Support the Dojo",
@@ -3187,7 +3268,23 @@
             "persistLinesLabel": "Show already-calculated lines when engine is disabled",
             "showCloudDbLabel": "Show Chess Cloud Database evaluation",
             "doneButton": "Done",
-            "depthDisplay": "Depth {depth}"
+            "depthDisplay": "Depth {depth}",
+            "engineDescription_stockfish_18": "Best for desktop",
+            "engineDescription_stockfish_18_lite": "Best for mobile and weaker desktops",
+            "engineDescription_stockfish_17": "Previous version",
+            "engineDescription_stockfish_16": "Previous version",
+            "engineDescription_stockfish_11": "Faster than NNUE but less accurate",
+            "engineTechDescription_stockfish_18": "Evaluation is performed by Stockfish's neural network.",
+            "engineTechDescription_stockfish_18_lite": "Evaluation is performed by a smaller Stockfish neural network.",
+            "engineTechDescription_stockfish_17": "Evaluation is performed by Stockfish's neural network.",
+            "engineTechDescription_stockfish_16": "Evaluation is performed by Stockfish's neural network.",
+            "engineTechDescription_stockfish_11": "Evaluation is performed using various heuristics and rules. Faster, but much less accurate than NNUE.",
+            "engineLocation": "in local browser",
+            "evalType_eval": "Evaluation",
+            "evalType_wdl": "Win / Draw / Loss",
+            "failedToQueueAnalysis": "Failed to queue analysis",
+            "invalidFen": "Invalid FEN provided",
+            "failedToFetchData": "Failed to fetch data"
         },
         "explorer": {
             "columnMove": "Move",
@@ -3536,7 +3633,8 @@
                 "keyEnter": "Enter",
                 "keyEscape": "Escape",
                 "keyTab": "Tab",
-                "keyBackspace": "Backspace"
+                "keyBackspace": "Backspace",
+                "fieldRequired": "This field is required"
             },
             "comments": {
                 "showCommentsLabel": "Show Comments From",
@@ -3560,7 +3658,8 @@
                 "postCommentTooltip": "Post Comment. Tip: you can also use shift+enter while typing.",
                 "replyPlaceholder": "Reply to {displayName} ({cohort})",
                 "replyCancelButton": "cancel",
-                "replyPostButton": "reply"
+                "replyPostButton": "reply",
+                "updatedAt": "Updated at {date} \u2022 {time}"
             },
             "directories": {},
             "share": {
@@ -3613,7 +3712,9 @@
                 "mergeCancelButton": "Cancel",
                 "mergeLineButton": "Merge Line into Game",
                 "mergeSuccessMessage": "Line merged into game",
-                "openButton": "Open"
+                "openButton": "Open",
+                "gameAddedToFolder": "Game added to {name}",
+                "mergeLineError": "Cannot merge line from start position"
             },
             "tags": {
                 "doubleClickHint": "Double click a cell to edit",
@@ -3709,7 +3810,8 @@
                 "everyMoveSingular": "every move",
                 "everyMovesPlural": "every {count} moves",
                 "moveRange": "Moves {start}–{end}:",
-                "moveRangeOpen": "Moves {start}+:"
+                "moveRangeOpen": "Moves {start}+:",
+                "moveTooltip": "Move {value}"
             },
             "tools": {
                 "solitaireChessTitle": "Solitaire Chess (Guess the Move)",
@@ -3876,5 +3978,34 @@
                 "restart": "Restart"
             }
         }
+    },
+    "liveClasses": {
+        "pageTitle": "ChessDojo Live Classes",
+        "lectureTierHeading": "Lecture Tier",
+        "lectureTierDescription": "The Lecture Tier provides access to larger lecture-style classes on various topics like endgames, calculation, and openings. For $75/month, you get access to all lecture classes and recordings, as well as full access to the rest of the ChessDojo website.",
+        "freeSamplePrompt": "Not sure if these classes are for you? Watch a free sample of Kostya's calculation course below.",
+        "alreadySubscribed": "Already Subscribed",
+        "joinLectureTier": "Join Lecture Tier",
+        "gameReviewHeading": "Game & Profile Review",
+        "gameReviewDescription": "The Game & Profile Review tier provides access to smaller seminar-style classes. In these classes, the sensei reviews one player's game and profile each week. The highlighted player rotates each week. For $200/month, you get placed with a team of similarly rated players and access to weekly peer review and sensei review sessions with your team. You also get access to all lecture classes, as well as recordings from all lecture classes and the peer review and sensei review sessions of all game review teams.",
+        "viewGameReviewTeam": "View Game Review Team",
+        "joinGameReview": "Join Game & Profile Review",
+        "recordingsHeading": "Recordings",
+        "recordingsLink": "All recordings can be found <link>here</link>.",
+        "recordingsAvailable": "All classes are recorded and available for viewing on demand.",
+        "faqsHeading": "FAQs"
+    },
+    "errors": {
+        "notFound": "Resource not found",
+        "unknownError": "Unknown Error",
+        "errorDescription": "Congratulations! You have broken the site in a new and interesting way. To report this error, please send a Discord message to @jackstenglein with a description of what you were doing when the site broke and a copy of the error message below. Then refresh the page to continue using the site.",
+        "nullError": "Null error",
+        "noComponentStack": "No component stack"
+    },
+    "dojoDigest": {
+        "unsubscribeTitle": "Unsubscribe from Dojo Digest",
+        "unsubscribeSuccess": "{email} has been unsubscribed. Please allow 24 hours for this change to take effect.",
+        "emailLabel": "Email",
+        "unsubscribeButton": "Unsubscribe"
     }
 }

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -2,7 +2,10 @@
     "common": {
         "timezone": "[T] Timezone",
         "language": "[T] Language",
-        "browserDefault": "[T] Browser Default ({offset})"
+        "browserDefault": "[T] Browser Default ({offset})",
+        "timeMinutes": "[T] {minutes}m",
+        "timeHours": "[T] {hours}h",
+        "timeHoursMinutes": "[T] {hours}h {minutes}m"
     },
     "profile": {
         "editor": {
@@ -144,7 +147,9 @@
                 "Wed": "[T] Wed",
                 "Thur": "[T] Thur",
                 "Fri": "[T] Fri",
-                "Sat": "[T] Sat"
+                "Sat": "[T] Sat",
+                "activeOnlyTooltip": "[T] Only show tasks you have updated this week",
+                "activeOnlyLabel": "[T] Active Only"
             },
             "full": {
                 "heading": "[T] Full Training Plan",
@@ -164,7 +169,11 @@
                 "renewTooltip": "[T] It's time for you to renew this task!",
                 "renewLabel": "[T] Renew",
                 "minimumReachedTooltip": "[T] You've reached the minimum, keep going!",
-                "minimumReachedLabel": "[T] Minimum Reached"
+                "minimumReachedLabel": "[T] Minimum Reached",
+                "checkboxAriaLabel": "[T] Checkbox {name}",
+                "updateAriaLabel": "[T] Update {name}",
+                "graduateName": "[T] Graduate from {cohort}",
+                "graduateDescription": "[T] Move to the next cohort and get featured in the graduation show."
             },
             "graduation": {
                 "title": "[T] Graduate from {cohort}?",
@@ -254,7 +263,8 @@
                 "cohort": "[T] Cohort",
                 "deleteEntry": "[T] Delete entry",
                 "totalCount": "[T] Total {label} : {total}. Current Cohort: {cohortCount}",
-                "totalTime": "[T] Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m"
+                "totalTime": "[T] Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
+                "deleteAriaLabel": "[T] delete"
             },
             "progressUpdater": {
                 "markComplete": "[T] Mark as Completed?",
@@ -365,7 +375,8 @@
             "save": "[T] Save",
             "updateTitle": "[T] Update {name}?",
             "totalCount": "[T] Total Count: {totalCount}. Current Cohort: {cohortCount}",
-            "totalTime": "[T] Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m"
+            "totalTime": "[T] Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
+            "restDayCleared": "[T] Rest day cleared"
         },
         "info": {
             "type": "[T] Type",
@@ -841,14 +852,31 @@
         "clearAll": "[T] Clear All",
         "empty": "[T] No notifications",
         "view": "[T] View",
-        "delete": "[T] Delete notification"
+        "delete": "[T] Delete notification",
+        "newFollowerTitle": "[T] You have a new follower",
+        "explorerGameTitle": "[T] {count} new games were added with a position you follow.",
+        "calendarInviteTitle": "[T] You've been invited to an event on the calendar",
+        "roundRobinStartTitle": "[T] Round robin {cohort} {name} has started",
+        "gameCommentDescription": "[T] There are new comments on your game.",
+        "gameCommentReplyDescription": "[T] {count, plural, =1 {There is a new reply to a comment thread you participated in.} other {There are # new replies in comment threads you participated in.}}",
+        "gameReviewCompleteDescription": "[T] {reviewer} reviewed your game. Check the game settings for more info.",
+        "timelineCommentDescription": "[T] {count, plural, =1 {There is a new comment on your activity.} other {There are # new comments on your activity.}}",
+        "timelineReactionDescription": "[T] {count, plural, =1 {There is a new reaction on your activity.} other {There are # new reactions on your activity.}}",
+        "explorerGameDescription": "[T] A new game was added containing a position you follow.",
+        "clubJoinRequestDescription": "[T] {count, plural, =1 {There is a new request to join your club.} other {There are # new requests to join your club.}}",
+        "clubJoinApprovedDescription": "[T] Your request to join the club was approved.",
+        "calendarInviteDescription": "[T] {owner} invited you to an event at {date} {time}"
     },
     "timer": {
         "title": "[T] Timer",
         "workTimer": "[T] Work Timer",
         "pause": "[T] Pause",
         "start": "[T] Start",
-        "reset": "[T] Reset"
+        "reset": "[T] Reset",
+        "pauseTimer": "[T] Pause Timer ({time})",
+        "resumeTimer": "[T] Resume Timer ({time})",
+        "startTimer": "[T] Start Timer",
+        "clearAndRestart": "[T] Clear and Restart Timer"
     },
     "navbar": {
         "searchUsers": "[T] Search Users",
@@ -1581,7 +1609,29 @@
         "colorYoutube": "[T] Youtube",
         "eventNotFoundError": "[T] This event cannot be found. It is either fully booked, deleted or not available to your cohort.",
         "participantPaymentWarningOther": "[T] This user has not paid and will lose their booking in <30 min",
-        "participantPaymentWarningSelf": "[T] You have not completed payment and will lose your booking soon"
+        "participantPaymentWarningSelf": "[T] You have not completed payment and will lose your booking soon",
+        "meetingTitle": "[T] Meeting",
+        "groupMeetingTitle": "[T] Group Meeting ({count}/{max})",
+        "available1on1Title": "[T] Available - 1 on 1",
+        "availableGroupTitle": "[T] Available - Group",
+        "bookableGroupTitle": "[T] Bookable - Group ({count}/{max})",
+        "bookableTitle": "[T] Bookable - {name}",
+        "meetingCanceled": "[T] Meeting canceled",
+        "availabilityDeleted": "[T] Availability deleted",
+        "hideFilters": "[T] Hide Filters",
+        "showFilters": "[T] Show Filters",
+        "validationRequired": "[T] This field is required",
+        "validationStartInvalid": "[T] Start time must be a valid time",
+        "validationEndInvalid": "[T] End time must be a valid time",
+        "validationEndTooEarly": "[T] End time must be at least one hour after start time",
+        "validationIntegerRequired": "[T] You must specify an integer greater than 0",
+        "validationNumberRequired": "[T] You must specify a number",
+        "validationDollarAmount": "[T] You must specify a valid dollar amount with up to 2 decimal places",
+        "validationMinPrice": "[T] Price must be at least $5",
+        "validationTypeRequired": "[T] At least one type is required",
+        "validationCohortRequired": "[T] At least one cohort is required",
+        "validationInviteRequired": "[T] At least one user is required when the event is invite-only",
+        "validationCountPositive": "[T] Must be greater than 0"
     },
     "meeting": {
         "title": "[T] Meetings",
@@ -1699,7 +1749,8 @@
             "nullMoves": "[T] Null Moves",
             "tags": "[T] Tags",
             "clockTimes": "[T] Clock Times",
-            "cancel": "[T] Cancel"
+            "cancel": "[T] Cancel",
+            "requestTimedOut": "[T] Request timed out"
         },
         "visibilityDialog": {
             "unlistTitle": "[T] {count, plural, =1 {Unlist Game?} other {Unlist {count} Games?}}",
@@ -2002,7 +2053,9 @@
             "gamePage": {
                 "preflightHint": "[T] You can fill this data out now or later in settings."
             }
-        }
+        },
+        "reviewTypeQuick": "[T] Quick",
+        "reviewTypeDeepDive": "[T] Deep Dive"
     },
     "courses": {
         "filters": {
@@ -2171,7 +2224,12 @@
                 "columnRating": "[T] Rating"
             },
             "pairings": {
-                "noOpponent": "[T] No Opponent"
+                "noOpponent": "[T] No Opponent",
+                "headerWhite": "[T] White",
+                "headerBlack": "[T] Black",
+                "headerResult": "[T] Result",
+                "headerGame": "[T] Game",
+                "unverifiedResultTooltip": "[T] This result has not been verified and may be changed later by the TD"
             },
             "info": {
                 "title": "[T] ChessDojo Open Classical",
@@ -2283,7 +2341,8 @@
             "tabs": {
                 "info": "[T] Info",
                 "tournaments": "[T] Tournaments",
-                "history": "[T] History"
+                "history": "[T] History",
+                "tabsAriaLabel": "[T] tournament viewer tabs"
             },
             "activity": {
                 "noGamesSubmitted": "[T] No games submitted yet",
@@ -2482,7 +2541,9 @@
                 "daysUnit": "[T] {days, plural, =1 {# day} other {# days}}",
                 "hoursUnit": "[T] {hours, plural, =1 {# hour} other {# hours}}",
                 "minutesUnit": "[T] {minutes, plural, =1 {# minute} other {# minutes}}",
-                "lessThanMinute": "[T] less than a minute"
+                "lessThanMinute": "[T] less than a minute",
+                "viewModeAriaLabel": "[T] view mode toggle",
+                "displayModeAriaLabel": "[T] display mode toggle"
             }
         }
     },
@@ -2840,7 +2901,8 @@
                 "tableHeaderCohort": "[T] Dojo Cohort",
                 "tableHeaderChesscom": "[T] Chess.com Bot",
                 "tableHeaderLichess": "[T] Lichess Bot"
-            }
+            },
+            "iframeTitle": "[T] Dojo Guide To Bots"
         },
         "liveClasses": {
             "title": "[T] Live Class Recordings",
@@ -2968,6 +3030,22 @@
             "puzzleRating": "[T] Puzzle Rating",
             "yourRating": "[T] Your Rating",
             "startRating": "[T] Start Rating"
+        },
+        "hintSection": {
+            "yourTurn": "[T] Your turn",
+            "recallMove": "[T] Recall the move for {color}.",
+            "findBestMove": "[T] Find the best move for {color}.",
+            "whatDidPlay": "[T] What did {color} play in this position?",
+            "whatWouldYouPlay": "[T] What would you play in this position?",
+            "incorrectRetry": "[T] Incorrect, please try again.",
+            "retry": "[T] Retry",
+            "enterHint": "[T] (Enter)",
+            "goodMove": "[T] Good move!",
+            "next": "[T] Next",
+            "memorizeComplete": "[T] Great job memorizing this game!",
+            "puzzleComplete": "[T] Great job completing this puzzle",
+            "restart": "[T] Restart",
+            "nextPuzzle": "[T] Next Puzzle"
         }
     },
     "exams": {
@@ -3086,7 +3164,10 @@
             "tooltipScoreRatingNewline": "[T] Score: {x},\nRating: {y}",
             "xAxisLabel": "[T] Score",
             "yAxisLabel": "[T] Normalized Rating"
-        }
+        },
+        "tacticsTest": "[T] Tactics Test",
+        "checkmateTest": "[T] Checkmate Test",
+        "endgameTest": "[T] Endgame Test"
     },
     "donate": {
         "title": "[T] Support the Dojo",
@@ -3187,7 +3268,23 @@
             "persistLinesLabel": "[T] Show already-calculated lines when engine is disabled",
             "showCloudDbLabel": "[T] Show Chess Cloud Database evaluation",
             "doneButton": "[T] Done",
-            "depthDisplay": "[T] Depth {depth}"
+            "depthDisplay": "[T] Depth {depth}",
+            "engineDescription_stockfish_18": "[T] Best for desktop",
+            "engineDescription_stockfish_18_lite": "[T] Best for mobile and weaker desktops",
+            "engineDescription_stockfish_17": "[T] Previous version",
+            "engineDescription_stockfish_16": "[T] Previous version",
+            "engineDescription_stockfish_11": "[T] Faster than NNUE but less accurate",
+            "engineTechDescription_stockfish_18": "[T] Evaluation is performed by Stockfish's neural network.",
+            "engineTechDescription_stockfish_18_lite": "[T] Evaluation is performed by a smaller Stockfish neural network.",
+            "engineTechDescription_stockfish_17": "[T] Evaluation is performed by Stockfish's neural network.",
+            "engineTechDescription_stockfish_16": "[T] Evaluation is performed by Stockfish's neural network.",
+            "engineTechDescription_stockfish_11": "[T] Evaluation is performed using various heuristics and rules. Faster, but much less accurate than NNUE.",
+            "engineLocation": "[T] in local browser",
+            "evalType_eval": "[T] Evaluation",
+            "evalType_wdl": "[T] Win / Draw / Loss",
+            "failedToQueueAnalysis": "[T] Failed to queue analysis",
+            "invalidFen": "[T] Invalid FEN provided",
+            "failedToFetchData": "[T] Failed to fetch data"
         },
         "explorer": {
             "columnMove": "[T] Move",
@@ -3536,7 +3633,8 @@
                 "keyEnter": "[T] Enter",
                 "keyEscape": "[T] Escape",
                 "keyTab": "[T] Tab",
-                "keyBackspace": "[T] Backspace"
+                "keyBackspace": "[T] Backspace",
+                "fieldRequired": "[T] This field is required"
             },
             "comments": {
                 "showCommentsLabel": "[T] Show Comments From",
@@ -3560,7 +3658,8 @@
                 "postCommentTooltip": "[T] Post Comment. Tip: you can also use shift+enter while typing.",
                 "replyPlaceholder": "[T] Reply to {displayName} ({cohort})",
                 "replyCancelButton": "[T] cancel",
-                "replyPostButton": "[T] reply"
+                "replyPostButton": "[T] reply",
+                "updatedAt": "[T] Updated at {date} \u2022 {time}"
             },
             "directories": {},
             "share": {
@@ -3613,7 +3712,9 @@
                 "mergeCancelButton": "[T] Cancel",
                 "mergeLineButton": "[T] Merge Line into Game",
                 "mergeSuccessMessage": "[T] Line merged into game",
-                "openButton": "[T] Open"
+                "openButton": "[T] Open",
+                "gameAddedToFolder": "[T] Game added to {name}",
+                "mergeLineError": "[T] Cannot merge line from start position"
             },
             "tags": {
                 "doubleClickHint": "[T] Double click a cell to edit",
@@ -3709,7 +3810,8 @@
                 "everyMoveSingular": "[T] every move",
                 "everyMovesPlural": "[T] every {count} moves",
                 "moveRange": "[T] Moves {start}–{end}:",
-                "moveRangeOpen": "[T] Moves {start}+:"
+                "moveRangeOpen": "[T] Moves {start}+:",
+                "moveTooltip": "[T] Move {value}"
             },
             "tools": {
                 "solitaireChessTitle": "[T] Solitaire Chess (Guess the Move)",
@@ -3876,5 +3978,34 @@
                 "restart": "[T] Restart"
             }
         }
+    },
+    "liveClasses": {
+        "pageTitle": "[T] ChessDojo Live Classes",
+        "lectureTierHeading": "[T] Lecture Tier",
+        "lectureTierDescription": "[T] The Lecture Tier provides access to larger lecture-style classes on various topics like endgames, calculation, and openings. For $75/month, you get access to all lecture classes and recordings, as well as full access to the rest of the ChessDojo website.",
+        "freeSamplePrompt": "[T] Not sure if these classes are for you? Watch a free sample of Kostya's calculation course below.",
+        "alreadySubscribed": "[T] Already Subscribed",
+        "joinLectureTier": "[T] Join Lecture Tier",
+        "gameReviewHeading": "[T] Game & Profile Review",
+        "gameReviewDescription": "[T] The Game & Profile Review tier provides access to smaller seminar-style classes. In these classes, the sensei reviews one player's game and profile each week. The highlighted player rotates each week. For $200/month, you get placed with a team of similarly rated players and access to weekly peer review and sensei review sessions with your team. You also get access to all lecture classes, as well as recordings from all lecture classes and the peer review and sensei review sessions of all game review teams.",
+        "viewGameReviewTeam": "[T] View Game Review Team",
+        "joinGameReview": "[T] Join Game & Profile Review",
+        "recordingsHeading": "[T] Recordings",
+        "recordingsLink": "[T] All recordings can be found <link>here</link>.",
+        "recordingsAvailable": "[T] All classes are recorded and available for viewing on demand.",
+        "faqsHeading": "[T] FAQs"
+    },
+    "errors": {
+        "notFound": "[T] Resource not found",
+        "unknownError": "[T] Unknown Error",
+        "errorDescription": "[T] Congratulations! You have broken the site in a new and interesting way. To report this error, please send a Discord message to @jackstenglein with a description of what you were doing when the site broke and a copy of the error message below. Then refresh the page to continue using the site.",
+        "nullError": "[T] Null error",
+        "noComponentStack": "[T] No component stack"
+    },
+    "dojoDigest": {
+        "unsubscribeTitle": "[T] Unsubscribe from Dojo Digest",
+        "unsubscribeSuccess": "[T] {email} has been unsubscribed. Please allow 24 hours for this change to take effect.",
+        "emailLabel": "[T] Email",
+        "unsubscribeButton": "[T] Unsubscribe"
     }
 }

--- a/frontend/src/ErrorBoundary.tsx
+++ b/frontend/src/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 // Based off of https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary
 
 import { Container, Stack, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { EventType, trackEvent } from './analytics/events';
 import { logger } from './logging/logger';
@@ -10,6 +11,23 @@ interface ErrorBoundaryState {
     error?: Error;
     info?: ErrorInfo;
 }
+
+const ErrorDisplay = ({ error, info }: { error?: Error; info?: ErrorInfo }) => {
+    const t = useTranslations('errors');
+    return (
+        <Container maxWidth='md' sx={{ pt: 6, pb: 4 }}>
+            <Stack spacing={4}>
+                <Typography variant='h5'>{t('unknownError')}</Typography>
+                <Typography variant='h6'>{t('errorDescription')}</Typography>
+
+                <Typography variant='body1' color='error' whiteSpace='pre-line'>
+                    {error ? error.toString() : t('nullError')}
+                    {info ? info.componentStack : t('noComponentStack')}
+                </Typography>
+            </Stack>
+        </Container>
+    );
+};
 
 class ErrorBoundary extends Component<React.PropsWithChildren, ErrorBoundaryState> {
     constructor(props: { children: ReactNode }) {
@@ -35,24 +53,7 @@ class ErrorBoundary extends Component<React.PropsWithChildren, ErrorBoundaryStat
             return this.props.children;
         }
 
-        return (
-            <Container maxWidth='md' sx={{ pt: 6, pb: 4 }}>
-                <Stack spacing={4}>
-                    <Typography variant='h5'>Unknown Error</Typography>
-                    <Typography variant='h6'>
-                        Congratulations! You have broken the site in a new and interesting way. To
-                        report this error, please send a Discord message to @jackstenglein with a
-                        description of what you were doing when the site broke and a copy of the
-                        error message below. Then refresh the page to continue using the site.
-                    </Typography>
-
-                    <Typography variant='body1' color='error' whiteSpace='pre-line'>
-                        {this.state.error ? this.state.error.toString() : 'Null error'}
-                        {this.state.info ? this.state.info.componentStack : 'No component stack'}
-                    </Typography>
-                </Stack>
-            </Container>
-        );
+        return <ErrorDisplay error={this.state.error} info={this.state.info} />;
     }
 }
 

--- a/frontend/src/NotFoundPage.tsx
+++ b/frontend/src/NotFoundPage.tsx
@@ -1,10 +1,13 @@
 import { Container, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 
 const NotFoundPage = () => {
+    const t = useTranslations('errors');
+
     return (
         <Container maxWidth='md' sx={{ pt: 6, pb: 4 }}>
             <Typography variant='h4'>404</Typography>
-            <Typography variant='h6'>Resource not found</Typography>
+            <Typography variant='h6'>{t('notFound')}</Typography>
         </Container>
     );
 };

--- a/frontend/src/app/(scoreboard)/calendar/CalendarPage.tsx
+++ b/frontend/src/app/(scoreboard)/calendar/CalendarPage.tsx
@@ -30,13 +30,17 @@ import type { EventRendererProps, SchedulerRef } from '@jackstenglein/react-sche
 import { ProcessedEvent } from '@jackstenglein/react-scheduler/types';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
 import { Button, Container, Grid, Snackbar, Stack, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { RRule } from 'rrule';
+
+type TranslateFn = (key: string, values?: Record<string, string | number>) => string;
 
 function processAvailability(
     user: User | undefined,
     filters: Filters,
     event: Event,
+    t: TranslateFn,
 ): ProcessedEvent | null {
     if (event.status === EventStatus.Canceled) {
         return null;
@@ -58,10 +62,11 @@ function processAvailability(
         const title =
             event.title ||
             (event.maxParticipants === 1
-                ? 'Meeting'
-                : `Group Meeting (${Object.values(event.participants).length}/${
-                      event.maxParticipants
-                  })`);
+                ? t('meetingTitle')
+                : t('groupMeetingTitle', {
+                      count: Object.values(event.participants).length,
+                      max: event.maxParticipants,
+                  }));
 
         const isOwner = event.owner === user.username;
         const editable =
@@ -92,7 +97,7 @@ function processAvailability(
 
         const title =
             event.title ||
-            (event.maxParticipants === 1 ? 'Available - 1 on 1' : 'Available - Group');
+            (event.maxParticipants === 1 ? t('available1on1Title') : t('availableGroupTitle'));
         return {
             event_id: event.id,
             title: title,
@@ -146,10 +151,11 @@ function processAvailability(
         title:
             event.title ||
             (event.maxParticipants > 1
-                ? `Bookable - Group (${Object.values(event.participants).length}/${
-                      event.maxParticipants
-                  })`
-                : `Bookable - ${event.ownerDisplayName}`),
+                ? t('bookableGroupTitle', {
+                      count: Object.values(event.participants).length,
+                      max: event.maxParticipants,
+                  })
+                : t('bookableTitle', { name: event.ownerDisplayName })),
         start: new Date(event.startTime),
         end: new Date(event.endTime),
         color: 'book.main',
@@ -352,6 +358,7 @@ export function getProcessedEvents(
     user: User | undefined,
     filters: Filters,
     events: Event[],
+    t: TranslateFn,
 ): ProcessedEvent[] {
     const result: ProcessedEvent[] = [];
 
@@ -367,7 +374,7 @@ export function getProcessedEvents(
         }
 
         if (event.type === EventType.Availability) {
-            processedEvent = processAvailability(user, filters, event);
+            processedEvent = processAvailability(user, filters, event, t);
         } else if (event.type === EventType.Dojo) {
             processedEvent = processDojoEvent(user, filters, event);
         } else if (event.type === EventType.LigaTournament) {
@@ -390,6 +397,7 @@ export function getProcessedEvents(
 }
 
 export default function CalendarPage() {
+    const t = useTranslations('calendar');
     const { user } = useAuth();
     const api = useApi();
     const isFreeTier = useFreeTier();
@@ -418,7 +426,7 @@ export default function CalendarPage() {
                 // scheduler library
                 await api.deleteEvent(id);
                 removeEvent(id);
-                deleteRequest.onSuccess('Availability deleted');
+                deleteRequest.onSuccess(t('availabilityDeleted'));
                 return id;
             } catch (err) {
                 deleteRequest.onFailure(err);
@@ -498,8 +506,8 @@ export default function CalendarPage() {
     );
 
     const processedEvents = useMemo(() => {
-        return getProcessedEvents(user, filters, events);
-    }, [user, filters, events]);
+        return getProcessedEvents(user, filters, events, t);
+    }, [user, filters, events, t]);
 
     useEffect(() => {
         calendarRef.current?.scheduler.handleState(processedEvents, 'events');
@@ -569,7 +577,7 @@ export default function CalendarPage() {
                 autoHideDuration={6000}
                 onClose={() => setCanceled(false)}
                 anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
-                message='Meeting canceled'
+                message={t('meetingCanceled')}
             />
 
             <Grid container spacing={2}>
@@ -579,7 +587,7 @@ export default function CalendarPage() {
                         startIcon={showFilters ? <VisibilityOff /> : <Visibility />}
                         sx={{ display: { xs: 'none', md: 'inline-flex' } }}
                     >
-                        {showFilters ? 'Hide Filters' : 'Show Filters'}
+                        {showFilters ? t('hideFilters') : t('showFilters')}
                     </Button>
                     {showFilters && <CalendarFilters filters={filters} />}
                 </Grid>

--- a/frontend/src/app/(scoreboard)/coaching/CoachingCalendar.tsx
+++ b/frontend/src/app/(scoreboard)/coaching/CoachingCalendar.tsx
@@ -29,6 +29,7 @@ const CoachingCalendar: React.FC<CoachingCalendarProps> = ({
     request,
 }) => {
     const t = useTranslations('coaching.calendar');
+    const tCalendar = useTranslations('calendar');
     const api = useApi();
     const user = useAuth().user;
     const calendarRef = useRef<SchedulerRef>(null);
@@ -40,8 +41,8 @@ const CoachingCalendar: React.FC<CoachingCalendarProps> = ({
 
     const processedEvents = useMemo(() => {
         const modifiedFilters = { ...filters, coaching: true };
-        return getProcessedEvents(user, modifiedFilters, events);
-    }, [user, filters, events]);
+        return getProcessedEvents(user, modifiedFilters, events, tCalendar);
+    }, [user, filters, events, tCalendar]);
 
     useEffect(() => {
         calendarRef.current?.scheduler.handleState(processedEvents, 'events');

--- a/frontend/src/app/(scoreboard)/dojodigest/unsubscribe/UnsubscribePage.tsx
+++ b/frontend/src/app/(scoreboard)/dojodigest/unsubscribe/UnsubscribePage.tsx
@@ -6,9 +6,11 @@ import { AuthStatus, useAuth } from '@/auth/Auth';
 import LoadingPage from '@/loading/LoadingPage';
 import { LoadingButton } from '@mui/lab';
 import { Container, Stack, TextField, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 
 const UnsubscribePage = () => {
+    const t = useTranslations('dojoDigest');
     const [email, setEmail] = useState('');
     const request = useRequest();
     const auth = useAuth();
@@ -36,12 +38,9 @@ const UnsubscribePage = () => {
         return (
             <Container maxWidth='md' sx={{ py: 4 }}>
                 <Stack spacing={4}>
-                    <Typography variant='h6'>Unsubscribe from Dojo Digest</Typography>
+                    <Typography variant='h6'>{t('unsubscribeTitle')}</Typography>
 
-                    <Typography>
-                        {email} has been unsubscribed. Please allow 24 hours for this change to take
-                        effect.
-                    </Typography>
+                    <Typography>{t('unsubscribeSuccess', { email })}</Typography>
                 </Stack>
             </Container>
         );
@@ -52,16 +51,20 @@ const UnsubscribePage = () => {
             <RequestSnackbar request={request} />
 
             <Stack spacing={4}>
-                <Typography variant='h6'>Unsubscribe from Dojo Digest</Typography>
+                <Typography variant='h6'>{t('unsubscribeTitle')}</Typography>
 
-                <TextField label='Email' value={email} onChange={(e) => setEmail(e.target.value)} />
+                <TextField
+                    label={t('emailLabel')}
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                />
 
                 <LoadingButton
                     variant='contained'
                     loading={request.isLoading()}
                     onClick={onUnsubscribe}
                 >
-                    Unsubscribe
+                    {t('unsubscribeButton')}
                 </LoadingButton>
             </Stack>
         </Container>

--- a/frontend/src/app/(scoreboard)/learn/guides/page.tsx
+++ b/frontend/src/app/(scoreboard)/learn/guides/page.tsx
@@ -311,7 +311,7 @@ export default function Page() {
                             <Box sx={{ mt: 3, mb: 3, width: 1, aspectRatio: '1.77' }}>
                                 <iframe
                                     src='https://www.youtube.com/embed/rGHf_qMR3uo'
-                                    title={`Dojo Guide To Bots`}
+                                    title={t('iframeTitle')}
                                     allow='accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share'
                                     allowFullScreen={true}
                                     style={{ width: '100%', height: '100%' }}
@@ -329,7 +329,7 @@ export default function Page() {
                             <Box sx={{ mt: 3, mb: 3, width: 1, aspectRatio: '1.77' }}>
                                 <iframe
                                     src='https://player.vimeo.com/video/705555806'
-                                    title={`Dojo Guide To Bots`}
+                                    title={t('iframeTitle')}
                                     allow='accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share'
                                     allowFullScreen={true}
                                     style={{ width: '100%', height: '100%' }}
@@ -347,7 +347,7 @@ export default function Page() {
                             <Box sx={{ mt: 3, mb: 3, width: 1, aspectRatio: '1.77' }}>
                                 <iframe
                                     src='https://player.vimeo.com/video/694563363'
-                                    title={`Dojo Guide To Bots`}
+                                    title={t('iframeTitle')}
                                     allow='accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share'
                                     allowFullScreen={true}
                                     style={{ width: '100%', height: '100%' }}
@@ -390,7 +390,7 @@ export default function Page() {
                             <Box sx={{ mt: 3, mb: 3, width: 1, aspectRatio: '1.77' }}>
                                 <iframe
                                     src='https://www.youtube.com/embed/WsZknsdk504'
-                                    title={`Dojo Guide To Bots`}
+                                    title={t('iframeTitle')}
                                     allow='accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share'
                                     allowFullScreen={true}
                                     style={{ width: '100%', height: '100%' }}

--- a/frontend/src/app/(scoreboard)/live-classes/LiveClassesPage.tsx
+++ b/frontend/src/app/(scoreboard)/live-classes/LiveClassesPage.tsx
@@ -36,6 +36,7 @@ const SAMPLE_LIVE_CLASS: LiveClass = {
 };
 
 export default function LiveClassesPage() {
+    const tPage = useTranslations('liveClasses');
     const t = useTranslations('help');
     const { user } = useAuth();
     const subscriptionTier = getSubscriptionTier(user);
@@ -76,7 +77,7 @@ export default function LiveClassesPage() {
     return (
         <Container sx={{ py: 5 }}>
             <Typography variant='h3' fontWeight='bold' mx='auto' textAlign='center'>
-                ChessDojo Live Classes
+                {tPage('pageTitle')}
             </Typography>
 
             {!isGameReviewUser && (
@@ -87,15 +88,10 @@ export default function LiveClassesPage() {
             )}
 
             <Typography variant='h5' mt={4} fontWeight='bold'>
-                Lecture Tier
+                {tPage('lectureTierHeading')}
             </Typography>
             <Typography variant='h6' mt={2}>
-                The Lecture Tier provides access to larger lecture-style classes on various topics
-                like endgames, calculation, and openings. For $75/month, you get access to all
-                lecture classes and recordings, as well as full access to the rest of the ChessDojo
-                website.{' '}
-                {!isLiveClassUser &&
-                    `Not sure if these classes are for you? Watch a free sample of Kostya's calculation course below.`}
+                {tPage('lectureTierDescription')} {!isLiveClassUser && tPage('freeSamplePrompt')}
             </Typography>
 
             <Button
@@ -111,7 +107,7 @@ export default function LiveClassesPage() {
                 color='subscribe'
                 loading={request.isLoading() && tier === SubscriptionTier.Lecture}
             >
-                {isLectureUser ? 'Already Subscribed' : 'Join Lecture Tier'}
+                {isLectureUser ? tPage('alreadySubscribed') : tPage('joinLectureTier')}
             </Button>
 
             <Box mt={4}>
@@ -124,7 +120,7 @@ export default function LiveClassesPage() {
             </Box>
 
             <Typography variant='h5' mt={8} fontWeight='bold'>
-                Game & Profile Review
+                {tPage('gameReviewHeading')}
             </Typography>
 
             <Grid
@@ -135,13 +131,7 @@ export default function LiveClassesPage() {
             >
                 <Grid size={{ xs: 12, md: 6 }}>
                     <Typography variant='h6' mt={2}>
-                        The Game & Profile Review tier provides access to smaller seminar-style
-                        classes. In these classes, the sensei reviews one player's game and profile
-                        each week. The highlighted player rotates each week. For $200/month, you get
-                        placed with a team of similarly rated players and access to weekly peer
-                        review and sensei review sessions with your team. You also get access to all
-                        lecture classes, as well as recordings from all lecture classes and the peer
-                        review and sensei review sessions of all game review teams.
+                        {tPage('gameReviewDescription')}
                     </Typography>
                     <Button
                         href={isGameReviewUser ? '/profile?view=classes' : undefined}
@@ -162,7 +152,7 @@ export default function LiveClassesPage() {
                         color='subscribe'
                         loading={request.isLoading() && tier === SubscriptionTier.GameReview}
                     >
-                        {isGameReviewUser ? 'View Game Review Team' : 'Join Game & Profile Review'}
+                        {isGameReviewUser ? tPage('viewGameReviewTeam') : tPage('joinGameReview')}
                     </Button>
                 </Grid>
                 <Grid
@@ -180,20 +170,18 @@ export default function LiveClassesPage() {
             </Grid>
 
             <Typography variant='h5' mt={8} fontWeight='bold'>
-                Recordings
+                {tPage('recordingsHeading')}
             </Typography>
             <Typography variant='h6' mt={2}>
-                {isLiveClassUser ? (
-                    <>
-                        All recordings can be found <Link href='/learn/live-classes'>here</Link>.
-                    </>
-                ) : (
-                    <>All classes are recorded and available for viewing on demand.</>
-                )}
+                {isLiveClassUser
+                    ? tPage.rich('recordingsLink', {
+                          link: (chunks) => <Link href='/learn/live-classes'>{chunks}</Link>,
+                      })
+                    : tPage('recordingsAvailable')}
             </Typography>
 
             <Typography variant='h4' mt={8}>
-                FAQs
+                {tPage('faqsHeading')}
             </Typography>
             {getLiveClassesFaq(t).items.map((item) => (
                 <Stack key={item.title} mt={3}>

--- a/frontend/src/app/(scoreboard)/newsfeed/(detail)/[owner]/[id]/GraduationNewsfeedItem.tsx
+++ b/frontend/src/app/(scoreboard)/newsfeed/(detail)/[owner]/[id]/GraduationNewsfeedItem.tsx
@@ -14,6 +14,7 @@ const richTags = {
 
 const GraduationNewsfeedItem: React.FC<GraduationNewsfeedItemProps> = ({ entry }) => {
     const t = useTranslations('newsfeed.graduation');
+    const tCommon = useTranslations('common');
 
     if (!entry.graduationInfo) {
         return (
@@ -50,13 +51,13 @@ const GraduationNewsfeedItem: React.FC<GraduationNewsfeedItemProps> = ({ entry }
                     <Typography component='span' color='text.secondary'>
                         {t('dojoTime')}
                     </Typography>{' '}
-                    {formatTime(entry.graduationInfo.dojoMinutes || 0)}
+                    {formatTime(entry.graduationInfo.dojoMinutes || 0, tCommon)}
                 </Typography>
                 <Typography>
                     <Typography component='span' color='text.secondary'>
                         {t('nonDojoTime')}
                     </Typography>{' '}
-                    {formatTime(entry.graduationInfo.nonDojoMinutes || 0)}
+                    {formatTime(entry.graduationInfo.nonDojoMinutes || 0, tCommon)}
                 </Typography>
                 <Typography>
                     <Typography component='span' color='text.secondary'>

--- a/frontend/src/app/(scoreboard)/scoreboard/stats/StatisticsPage.tsx
+++ b/frontend/src/app/(scoreboard)/scoreboard/stats/StatisticsPage.tsx
@@ -4,6 +4,7 @@ import { useApi } from '@/api/Api';
 import { RequestSnackbar, useRequest } from '@/api/Request';
 import { useAuth } from '@/auth/Auth';
 import ScoreboardViewSelector from '@/components/scoreboard/ScoreboardViewSelector';
+import { formatTime } from '@/database/requirement';
 import { UserStatistics } from '@/database/statistics';
 import { RatingSystem, dojoCohorts, formatRatingSystem } from '@/database/user';
 import LoadingPage from '@/loading/LoadingPage';
@@ -42,24 +43,19 @@ const decimalSecondaryAxes: AxisOptions<Datum>[] = [
     },
 ];
 
-export function formatTime(value: number) {
-    const hours = Math.floor(value / 60);
-    const minutes = Math.round(value % 60);
-    if (minutes === 0 && hours > 0) {
-        return `${hours}h`;
-    }
-    return `${hours}h ${minutes}m`;
-}
-
-const timeSecondaryAxes: AxisOptions<Datum>[] = [
-    {
-        scaleType: 'linear',
-        getValue: (datum) => datum.value,
-        formatters: {
-            scale: formatTime,
+function getTimeSecondaryAxes(
+    t: (key: string, values?: Record<string, string | number>) => string,
+): AxisOptions<Datum>[] {
+    return [
+        {
+            scaleType: 'linear',
+            getValue: (datum) => datum.value,
+            formatters: {
+                scale: (value: number) => formatTime(value, t),
+            },
         },
-    },
-];
+    ];
+}
 
 function getSeries(
     label: string,
@@ -138,6 +134,8 @@ function getAdminParticipantsSeries(
 
 export function StatisticsPage() {
     const t = useTranslations('scoreboard.stats');
+    const tCommon = useTranslations('common');
+    const timeSecondaryAxes = useMemo(() => getTimeSecondaryAxes(tCommon), [tCommon]);
     const api = useApi();
     const request = useRequest<UserStatistics>();
     const { user } = useAuth();
@@ -350,7 +348,7 @@ export function StatisticsPage() {
                     series={totalTimeData}
                     primaryAxis={primaryAxis}
                     secondaryAxes={timeSecondaryAxes}
-                    sumFormatter={formatTime}
+                    sumFormatter={(v) => formatTime(v, tCommon)}
                 />
                 <Chart
                     title={t('avgTimeSpent')}

--- a/frontend/src/app/(scoreboard)/tests/[type]/[id]/(instructions)/ExamInstructionsPage.tsx
+++ b/frontend/src/app/(scoreboard)/tests/[type]/[id]/(instructions)/ExamInstructionsPage.tsx
@@ -28,6 +28,7 @@ export function ExamInstructionsPage({ type, id }: { type: ExamType; id: string 
 
 function AuthExamInstructionPage({ user, type, id }: { user: User; type: ExamType; id: string }) {
     const t = useTranslations('exams.instructionsPage');
+    const tExams = useTranslations('exams');
     const { request, exam } = useExam({ type, id });
     const answerRequest = useRequest<ExamAnswer>();
     const router = useRouter();
@@ -55,7 +56,7 @@ function AuthExamInstructionPage({ user, type, id }: { user: User; type: ExamTyp
         <Container sx={{ py: 4 }} maxWidth={false}>
             <Container>
                 <Stack alignItems='start'>
-                    <Typography variant='h4'>{displayExamType(exam.type)}</Typography>
+                    <Typography variant='h4'>{displayExamType(exam.type, tExams)}</Typography>
                     <Typography variant='h5'>
                         {exam.cohortRange} {exam.name}
                     </Typography>

--- a/frontend/src/app/(scoreboard)/tournaments/open-classical/PairingsTable.tsx
+++ b/frontend/src/app/(scoreboard)/tournaments/open-classical/PairingsTable.tsx
@@ -5,6 +5,7 @@ import { OpenInNew, Warning } from '@mui/icons-material';
 import { Stack, Tooltip } from '@mui/material';
 import { DataGridPro, GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
 import { useTranslations } from 'next-intl';
+import { useMemo } from 'react';
 import { SiLichess } from 'react-icons/si';
 
 export function PlayerCell({ player }: { player: OpenClassicalPlayer }) {
@@ -49,83 +50,87 @@ export function PlayerCell({ player }: { player: OpenClassicalPlayer }) {
     );
 }
 
-export const pairingTableColumns: GridColDef<OpenClassicalPairing>[] = [
-    {
-        field: 'white',
-        headerName: 'White',
-        headerAlign: 'center',
-        valueGetter: (_value, row) =>
-            `${row.white.displayName} ${row.white.lichessUsername} ${row.white.discordUsername}`,
-        flex: 1,
-        renderCell(params) {
-            return <PlayerCell player={params.row.white} />;
+export function getPairingTableColumns(
+    t: (key: string) => string,
+): GridColDef<OpenClassicalPairing>[] {
+    return [
+        {
+            field: 'white',
+            headerName: t('headerWhite'),
+            headerAlign: 'center',
+            valueGetter: (_value, row) =>
+                `${row.white.displayName} ${row.white.lichessUsername} ${row.white.discordUsername}`,
+            flex: 1,
+            renderCell(params) {
+                return <PlayerCell player={params.row.white} />;
+            },
         },
-    },
-    {
-        field: 'black',
-        headerName: 'Black',
-        headerAlign: 'center',
-        valueGetter: (_value, row) =>
-            `${row.black.displayName} ${row.black.lichessUsername} ${row.black.discordUsername}`,
-        flex: 1,
-        renderCell(params) {
-            return <PlayerCell player={params.row.black} />;
+        {
+            field: 'black',
+            headerName: t('headerBlack'),
+            headerAlign: 'center',
+            valueGetter: (_value, row) =>
+                `${row.black.displayName} ${row.black.lichessUsername} ${row.black.discordUsername}`,
+            flex: 1,
+            renderCell(params) {
+                return <PlayerCell player={params.row.black} />;
+            },
         },
-    },
-    {
-        field: 'result',
-        headerName: 'Result',
-        flex: 0.5,
-        align: 'center',
-        headerAlign: 'center',
-        renderCell: (params: GridRenderCellParams<OpenClassicalPairing, string>) => {
-            if (params.value === '*' || params.value === '' || params.row.verified) {
+        {
+            field: 'result',
+            headerName: t('headerResult'),
+            flex: 0.5,
+            align: 'center',
+            headerAlign: 'center',
+            renderCell: (params: GridRenderCellParams<OpenClassicalPairing, string>) => {
+                if (params.value === '*' || params.value === '' || params.row.verified) {
+                    return (
+                        <Stack alignItems='center' justifyContent='center' height={1}>
+                            {params.value}
+                        </Stack>
+                    );
+                }
                 return (
-                    <Stack alignItems='center' justifyContent='center' height={1}>
-                        {params.value}
+                    <Stack
+                        direction='row'
+                        alignItems='center'
+                        justifyContent='center'
+                        spacing={1}
+                        height={1}
+                    >
+                        <div>{params.value}</div>
+                        <Tooltip title={t('unverifiedResultTooltip')}>
+                            <Warning color='warning' fontSize='small' />
+                        </Tooltip>
                     </Stack>
                 );
-            }
-            return (
-                <Stack
-                    direction='row'
-                    alignItems='center'
-                    justifyContent='center'
-                    spacing={1}
-                    height={1}
-                >
-                    <div>{params.value}</div>
-                    <Tooltip title='This result has not been verified and may be changed later by the TD'>
-                        <Warning color='warning' fontSize='small' />
-                    </Tooltip>
-                </Stack>
-            );
+            },
         },
-    },
-    {
-        field: 'gameUrl',
-        headerName: 'Game',
-        width: 75,
-        align: 'center',
-        headerAlign: 'center',
-        renderCell: (params: GridRenderCellParams<OpenClassicalPairing, string>) => {
-            if (
-                params.value &&
-                (params.value.startsWith('https://lichess.org/') ||
-                    params.value.startsWith('https://www.chess.com/'))
-            ) {
-                return (
-                    <Stack height={1} alignItems='center' justifyContent='center'>
-                        <a target='_blank' rel='noopener noreferrer' href={params.value}>
-                            <OpenInNew color='primary' fontSize='small' />
-                        </a>
-                    </Stack>
-                );
-            }
-            return null;
+        {
+            field: 'gameUrl',
+            headerName: t('headerGame'),
+            width: 75,
+            align: 'center',
+            headerAlign: 'center',
+            renderCell: (params: GridRenderCellParams<OpenClassicalPairing, string>) => {
+                if (
+                    params.value &&
+                    (params.value.startsWith('https://lichess.org/') ||
+                        params.value.startsWith('https://www.chess.com/'))
+                ) {
+                    return (
+                        <Stack height={1} alignItems='center' justifyContent='center'>
+                            <a target='_blank' rel='noopener noreferrer' href={params.value}>
+                                <OpenInNew color='primary' fontSize='small' />
+                            </a>
+                        </Stack>
+                    );
+                }
+                return null;
+            },
         },
-    },
-];
+    ];
+}
 
 export interface PairingsTableProps {
     openClassical: OpenClassical;
@@ -140,12 +145,14 @@ const PairingsTable: React.FC<PairingsTableProps> = ({
     ratingRange,
     round,
 }) => {
+    const t = useTranslations('tournaments.openClassical.pairings');
+    const columns = useMemo(() => getPairingTableColumns(t), [t]);
     const pairings =
         openClassical.sections[`${region}_${ratingRange}`]?.rounds[round - 1]?.pairings ?? [];
 
     return (
         <DataGridPro
-            columns={pairingTableColumns}
+            columns={columns}
             rows={pairings}
             getRowId={(pairing) =>
                 `${pairing.white.lichessUsername}-${pairing.black.lichessUsername}`

--- a/frontend/src/app/(scoreboard)/tournaments/open-classical/admin/PairingsTab.tsx
+++ b/frontend/src/app/(scoreboard)/tournaments/open-classical/admin/PairingsTab.tsx
@@ -16,9 +16,10 @@ import {
     TextField,
     Tooltip,
 } from '@mui/material';
-import { DataGridPro, GridActionsCellItem, GridColDef } from '@mui/x-data-grid-pro';
+import { DataGridPro, GridActionsCellItem } from '@mui/x-data-grid-pro';
+import { useTranslations } from 'next-intl';
 import { useMemo, useState } from 'react';
-import { PairingsTableProps, pairingTableColumns } from '../PairingsTable';
+import { getPairingTableColumns, PairingsTableProps } from '../PairingsTable';
 import Editor from './Editor';
 import EmailPairingsButton from './EmailPairingsButton';
 
@@ -115,22 +116,6 @@ const PairingsTab: React.FC<PairingsTabProps> = ({ openClassical, onUpdate }) =>
     );
 };
 
-const adminPairingTableColumns: GridColDef<OpenClassicalPairing>[] = [
-    ...pairingTableColumns,
-    {
-        field: 'reportOpponent',
-        headerName: 'Report Opponent',
-        type: 'boolean',
-        width: 125,
-    },
-    {
-        field: 'notes',
-        headerName: 'Notes',
-        headerAlign: 'center',
-        flex: 1,
-    },
-];
-
 interface AdminPairingsTableProps extends PairingsTableProps {
     onUpdate: (openClassical: OpenClassical) => void;
 }
@@ -142,31 +127,47 @@ const AdminPairingsTable: React.FC<AdminPairingsTableProps> = ({
     round,
     onUpdate,
 }) => {
+    const t = useTranslations('tournaments.openClassical.pairings');
     const [updatePairing, setUpdatePairing] = useState<OpenClassicalPairing>();
     const [updateResult, setUpdateResult] = useState('');
     const api = useApi();
     const updateRequest = useRequest();
 
     const columns = useMemo(() => {
-        return adminPairingTableColumns.concat({
-            field: 'actions',
-            type: 'actions',
-            headerName: 'Actions',
-            getActions: (params) => [
-                <Tooltip key='update-result' title='Update Result'>
-                    <GridActionsCellItem
-                        icon={<Edit />}
-                        label='Update Result'
-                        onClick={() => {
-                            setUpdateResult(params.row.result);
-                            setUpdatePairing(params.row);
-                        }}
-                    />
-                </Tooltip>,
-            ],
-            width: 70,
-        });
-    }, [setUpdatePairing]);
+        return [
+            ...getPairingTableColumns(t),
+            {
+                field: 'reportOpponent',
+                headerName: 'Report Opponent',
+                type: 'boolean' as const,
+                width: 125,
+            },
+            {
+                field: 'notes',
+                headerName: 'Notes',
+                headerAlign: 'center' as const,
+                flex: 1,
+            },
+            {
+                field: 'actions',
+                type: 'actions' as const,
+                headerName: 'Actions',
+                getActions: (params: { row: OpenClassicalPairing }) => [
+                    <Tooltip key='update-result' title='Update Result'>
+                        <GridActionsCellItem
+                            icon={<Edit />}
+                            label='Update Result'
+                            onClick={() => {
+                                setUpdateResult(params.row.result);
+                                setUpdatePairing(params.row);
+                            }}
+                        />
+                    </Tooltip>,
+                ],
+                width: 70,
+            },
+        ];
+    }, [t, setUpdatePairing]);
 
     const pairings =
         openClassical.sections[`${region}_${ratingRange}`]?.rounds[round - 1]?.pairings ?? [];

--- a/frontend/src/app/(scoreboard)/tournaments/round-robin/RoundRobinPage.tsx
+++ b/frontend/src/app/(scoreboard)/tournaments/round-robin/RoundRobinPage.tsx
@@ -49,7 +49,7 @@ export const RoundRobinPage = () => {
                     value={tabValue}
                     onChange={handleTabChange}
                     variant='fullWidth'
-                    aria-label='tournament viewer tabs'
+                    aria-label={t('tabsAriaLabel')}
                 >
                     <Tab
                         label={t('info')}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,12 +1,15 @@
 import { Layout } from '@/legacy/Layout';
 import { Container, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 
 export default function NotFound() {
+    const t = useTranslations('errors');
+
     return (
         <Layout>
             <Container maxWidth='md' sx={{ pt: 6, pb: 4 }}>
                 <Typography variant='h4'>404</Typography>
-                <Typography variant='h6'>Resource not found</Typography>
+                <Typography variant='h6'>{t('notFound')}</Typography>
             </Container>
         </Layout>
     );

--- a/frontend/src/board/pgn/boardTools/underboard/clock/ClockUsage.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/clock/ClockUsage.tsx
@@ -81,14 +81,18 @@ export interface Datum {
     eval?: number;
 }
 
-const primaryAxis: AxisOptions<Datum> = {
-    getValue: (datum) => datum.moveNumber,
-    scaleType: 'linear',
-    formatters: {
-        scale: (value) => (value % 1 === 0 ? `${value}` : ''),
-        tooltip: (value) => (value % 1 === 0 ? `Move ${value}` : ''),
-    },
-};
+function getPrimaryAxis(
+    t: (key: string, values?: Record<string, string | number>) => string,
+): AxisOptions<Datum> {
+    return {
+        getValue: (datum) => datum.moveNumber,
+        scaleType: 'linear',
+        formatters: {
+            scale: (value) => (value % 1 === 0 ? `${value}` : ''),
+            tooltip: (value) => (value % 1 === 0 ? t('moveTooltip', { value }) : ''),
+        },
+    };
+}
 
 const secondaryAxes: AxisOptions<Datum>[] = [
     {
@@ -135,14 +139,18 @@ const secondaryAxes: AxisOptions<Datum>[] = [
     },
 ];
 
-const barAxis: AxisOptions<Datum> = {
-    getValue: (datum) => datum.moveNumber,
-    scaleType: 'band',
-    position: 'left',
-    formatters: {
-        tooltip: (value) => `Move ${(value as number)?.toString()}`,
-    },
-};
+function getBarAxis(
+    t: (key: string, values?: Record<string, string | number>) => string,
+): AxisOptions<Datum> {
+    return {
+        getValue: (datum) => datum.moveNumber,
+        scaleType: 'band',
+        position: 'left',
+        formatters: {
+            tooltip: (value) => t('moveTooltip', { value: (value as number)?.toString() }),
+        },
+    };
+}
 
 const secondaryBarAxis: AxisOptions<Datum>[] = [
     {
@@ -246,6 +254,8 @@ interface ClockUsageProps {
 const ClockUsage: React.FC<ClockUsageProps> = ({ showEditor }) => {
     const { chess } = useChess();
     const t = useTranslations('analysisBoard.underboard.clock');
+    const primaryAxis = useMemo(() => getPrimaryAxis(t), [t]);
+    const barAxis = useMemo(() => getBarAxis(t), [t]);
     const light = useLightMode();
     const [forceRender, setForceRender] = useState(0);
     const reconcile = useReconcile();

--- a/frontend/src/board/pgn/boardTools/underboard/comments/Comment.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/comments/Comment.tsx
@@ -346,6 +346,7 @@ const EditableComment: React.FC<CommentProps> = ({ comment, move }) => {
 };
 
 const CommentInfo: React.FC<Omit<CommentProps, 'move'>> = ({ comment }) => {
+    const t = useTranslations('analysisBoard.underboard.comments');
     const viewer = useAuth().user;
 
     const createdAt = new Date(comment.createdAt);
@@ -380,7 +381,7 @@ const CommentInfo: React.FC<Omit<CommentProps, 'move'>> = ({ comment }) => {
                     • {createdAtDate} {createdAtTime}
                 </Typography>
                 {updatedAtDate && (
-                    <Tooltip title={`Updated at ${updatedAtDate} • ${updatedAtTime}`}>
+                    <Tooltip title={t('updatedAt', { date: updatedAtDate, time: updatedAtTime })}>
                         <Edit sx={{ color: 'text.secondary', fontSize: '0.8rem' }} />
                     </Tooltip>
                 )}

--- a/frontend/src/board/pgn/boardTools/underboard/settings/AdminSettings.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/AdminSettings.tsx
@@ -30,6 +30,7 @@ const GameReviewDetails: React.FC<AdminSettingsProps> = ({ game, onSaveGame }) =
     const request = useRequest();
     const api = useApi();
     const t = useTranslations('analysisBoard.underboard.settings');
+    const tGames = useTranslations('games');
 
     const requestDate = new Date(game.reviewRequestedAt || '');
     const requestDateStr = toDojoDateString(requestDate, user?.timezoneOverride);
@@ -78,7 +79,7 @@ const GameReviewDetails: React.FC<AdminSettingsProps> = ({ game, onSaveGame }) =
                     {review.type && (
                         <Typography>
                             {t('reviewTypeDisplayLabel', {
-                                type: displayGameReviewType(review.type),
+                                type: displayGameReviewType(review.type, tGames),
                             })}
                         </Typography>
                     )}
@@ -112,7 +113,7 @@ const GameReviewDetails: React.FC<AdminSettingsProps> = ({ game, onSaveGame }) =
                     </Typography>
                     <Typography>
                         {t('reviewTypeDisplayLabel', {
-                            type: displayGameReviewType(game.review.type),
+                            type: displayGameReviewType(game.review.type, tGames),
                         })}
                     </Typography>
                     <Typography>

--- a/frontend/src/board/pgn/boardTools/underboard/settings/RequestReviewDialog.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/settings/RequestReviewDialog.tsx
@@ -109,10 +109,10 @@ const SubmitDialogContent: React.FC<{
     const onPurchase = () => {
         const newErrors: Record<string, string> = {};
         if (!reviewType) {
-            newErrors.reviewType = 'This field is required';
+            newErrors.reviewType = t('fieldRequired');
         }
         if (!isConfirmed) {
-            newErrors.isConfirmed = 'This field is required';
+            newErrors.isConfirmed = t('fieldRequired');
         }
 
         setErrors(newErrors);
@@ -250,6 +250,7 @@ const SubmitDialogContent: React.FC<{
  */
 const CompletedDialogContent: React.FC<{ game: Game }> = ({ game }) => {
     const t = useTranslations('analysisBoard.underboard.settings');
+    const tGames = useTranslations('games');
     const user = useAuth().user;
 
     const review = game.review;
@@ -328,7 +329,7 @@ const CompletedDialogContent: React.FC<{ game: Game }> = ({ game }) => {
                     {review.type && (
                         <Typography>
                             {t('reviewTypeDisplayLabel', {
-                                type: displayGameReviewType(review.type),
+                                type: displayGameReviewType(review.type, tGames),
                             })}
                         </Typography>
                     )}
@@ -343,6 +344,7 @@ const CompletedDialogContent: React.FC<{ game: Game }> = ({ game }) => {
  */
 const PendingDialogContent: React.FC<{ game: Game }> = ({ game }) => {
     const t = useTranslations('analysisBoard.underboard.settings');
+    const tGames = useTranslations('games');
     const user = useAuth().user;
     const queueRequest = useRequest<number>();
     const api = useApi();
@@ -436,7 +438,7 @@ const PendingDialogContent: React.FC<{ game: Game }> = ({ game }) => {
                     {game.review?.type && (
                         <Typography>
                             {t('reviewTypeDisplayLabel', {
-                                type: displayGameReviewType(game.review.type),
+                                type: displayGameReviewType(game.review.type, tGames),
                             })}
                         </Typography>
                     )}

--- a/frontend/src/board/pgn/boardTools/underboard/share/MergeLineDialog.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/share/MergeLineDialog.tsx
@@ -88,7 +88,7 @@ export function MergeLineDialog({
 
         const renderMove = move || chess.currentMove();
         if (!renderMove) {
-            request.onFailure({ message: 'Cannot merge line from start position' });
+            request.onFailure({ message: t('mergeLineError') });
             return;
         }
 

--- a/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
@@ -118,7 +118,9 @@ export function ShareTab() {
                     },
                 ],
             });
-            addToFolderRequest.onSuccess(`Game added to ${resp.data.directory.name}`);
+            addToFolderRequest.onSuccess(
+                t('gameAddedToFolder', { name: resp.data.directory.name }),
+            );
             trackEvent(EventType.AddDirectoryItems, {
                 count: 1,
                 method: 'share_tab_add_to_folder',

--- a/frontend/src/board/pgn/pgnText/engine/EngineSection.tsx
+++ b/frontend/src/board/pgn/pgnText/engine/EngineSection.tsx
@@ -125,7 +125,10 @@ export default function EngineSection() {
                                 {engineInfo.shortName}
                             </Typography>
 
-                            <Tooltip title={engineInfo.techDescription} disableInteractive>
+                            <Tooltip
+                                title={t(`engineTechDescription_${engineInfo.name}`)}
+                                disableInteractive
+                            >
                                 <Typography
                                     color='dojoOrange'
                                     variant='caption'
@@ -148,7 +151,7 @@ export default function EngineSection() {
                         {(function engineDescription() {
                             if (!enabled) {
                                 return (
-                                    <Typography variant='caption'>{engineInfo.location}</Typography>
+                                    <Typography variant='caption'>{t('engineLocation')}</Typography>
                                 );
                             }
                             if (isGameOver) {

--- a/frontend/src/board/pgn/pgnText/engine/Settings.tsx
+++ b/frontend/src/board/pgn/pgnText/engine/Settings.tsx
@@ -140,7 +140,7 @@ export default function Settings() {
                                     </ListItemIcon>
                                     <ListItemText
                                         primary={engine.fullName}
-                                        secondary={engine.description}
+                                        secondary={t(`engineDescription_${engine.name}`)}
                                     />
                                 </MenuItem>
                             ))}
@@ -192,7 +192,7 @@ export default function Settings() {
                                     <FormControlLabel
                                         key={opt.value}
                                         value={opt.value}
-                                        label={opt.label}
+                                        label={t(`evalType_${opt.value}`)}
                                         control={<Radio />}
                                     />
                                 ))}

--- a/frontend/src/board/puzzle/HintSection.tsx
+++ b/frontend/src/board/puzzle/HintSection.tsx
@@ -1,5 +1,6 @@
 import { Move } from '@jackstenglein/chess';
 import { Button, Stack, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import React, { useCallback, useEffect, useRef } from 'react';
 
 import { BoardApi, Chess, reconcile, toColor } from '../Board';
@@ -23,14 +24,16 @@ interface HintSectionProps {
 }
 
 const TurnPrompt = ({ chess, playBothSides }: { chess: Chess; playBothSides: boolean }) => {
+    const t = useTranslations('puzzles.hintSection');
     return (
         <Stack>
             <Typography variant='h6' fontWeight='bold' color='text.secondary'>
-                Your turn
+                {t('yourTurn')}
             </Typography>
             <Typography color='text.secondary'>
-                {playBothSides ? 'Recall the move for ' : 'Find the best move for '}
-                {toColor(chess)}.
+                {playBothSides
+                    ? t('recallMove', { color: toColor(chess) })
+                    : t('findBestMove', { color: toColor(chess) })}
             </Typography>
         </Stack>
     );
@@ -42,11 +45,12 @@ const WaitingForMoveHint: React.FC<HintSectionProps> = ({
     coachUrl,
     playBothSides = false,
 }) => {
+    const t = useTranslations('puzzles.hintSection');
     let comment = move ? move.commentAfter : chess.pgn.gameComment.comment;
     if (!comment || comment.includes('[#]')) {
         comment = playBothSides
-            ? `What did ${toColor(chess)} play in this position?`
-            : 'What would you play in this position?';
+            ? t('whatDidPlay', { color: toColor(chess) })
+            : t('whatWouldYouPlay');
     }
 
     return (
@@ -68,6 +72,7 @@ const IncorrectMoveHint: React.FC<HintSectionProps> = ({
     coachUrl,
     onRetry,
 }) => {
+    const t = useTranslations('puzzles.hintSection');
     const upHandler = useCallback(
         (event: KeyboardEvent) => {
             if (event.key === 'Enter') {
@@ -87,7 +92,7 @@ const IncorrectMoveHint: React.FC<HintSectionProps> = ({
 
     return (
         <>
-            <ChatBubble>{move?.commentAfter || 'Incorrect, please try again.'}</ChatBubble>
+            <ChatBubble>{move?.commentAfter || t('incorrectRetry')}</ChatBubble>
             <Stack direction='row' justifyContent='space-between'>
                 <Button
                     variant='contained'
@@ -96,9 +101,9 @@ const IncorrectMoveHint: React.FC<HintSectionProps> = ({
                     sx={{ flexGrow: 1 }}
                     onClick={() => onRetry(board, chess)}
                 >
-                    Retry
+                    {t('retry')}
                     <br />
-                    (Enter)
+                    {t('enterHint')}
                 </Button>
                 <Coach src={coachUrl} />
             </Stack>
@@ -114,6 +119,7 @@ const CorrectMoveHint: React.FC<HintSectionProps> = ({
     playBothSides,
     onNext,
 }) => {
+    const t = useTranslations('puzzles.hintSection');
     const upHandler = useCallback(
         (event: KeyboardEvent) => {
             if (event.key === 'Enter' && !playBothSides) {
@@ -131,10 +137,10 @@ const CorrectMoveHint: React.FC<HintSectionProps> = ({
         };
     }, [upHandler]);
 
-    let chatText = move?.commentAfter || 'Good move!';
+    let chatText = move?.commentAfter || t('goodMove');
 
     if (playBothSides) {
-        chatText = `What did ${toColor(chess)} play in this position?`;
+        chatText = t('whatDidPlay', { color: toColor(chess) });
     }
 
     return (
@@ -151,9 +157,9 @@ const CorrectMoveHint: React.FC<HintSectionProps> = ({
                         sx={{ flexGrow: 1 }}
                         onClick={() => onNext(board, chess)}
                     >
-                        Next
+                        {t('next')}
                         <br />
-                        (Enter)
+                        {t('enterHint')}
                     </Button>
                 )}
                 <Coach src={coachUrl} />
@@ -217,9 +223,8 @@ const CompleteHint: React.FC<HintSectionProps> = ({
         };
     }, [onKeyDown, onKeyUp]);
 
-    const chatText = playBothSides
-        ? 'Great job memorizing this game!'
-        : 'Great job completing this puzzle';
+    const t = useTranslations('puzzles.hintSection');
+    const chatText = playBothSides ? t('memorizeComplete') : t('puzzleComplete');
 
     return (
         <>
@@ -237,7 +242,7 @@ const CompleteHint: React.FC<HintSectionProps> = ({
                             sx={{ flexGrow: 1 }}
                             onClick={() => onRestart(board, chess)}
                         >
-                            Restart
+                            {t('restart')}
                         </Button>
                         {onNextPuzzle && (
                             <Button
@@ -247,7 +252,7 @@ const CompleteHint: React.FC<HintSectionProps> = ({
                                 sx={{ flexGrow: 1 }}
                                 onClick={onNextPuzzle}
                             >
-                                Next Puzzle
+                                {t('nextPuzzle')}
                             </Button>
                         )}
                     </Stack>

--- a/frontend/src/components/calendar/eventEditor/EventEditor.tsx
+++ b/frontend/src/components/calendar/eventEditor/EventEditor.tsx
@@ -79,7 +79,7 @@ const EventEditor: React.FC<EventEditorProps> = ({ scheduler }) => {
     const formConfigs = getFormConfigs(t, labelT);
 
     const onSubmit = async () => {
-        const [event, errors] = validateEventEditor(user, originalEvent, editor);
+        const [event, errors] = validateEventEditor(user, originalEvent, editor, t);
         editor.setErrors(errors);
         if (Object.entries(errors).length > 0 || !event) {
             return;

--- a/frontend/src/components/calendar/eventEditor/eventValidation.ts
+++ b/frontend/src/components/calendar/eventEditor/eventValidation.ts
@@ -17,6 +17,8 @@ import {
     UseEventEditorResponse,
 } from './useEventEditor';
 
+type TranslateFn = (key: string) => string;
+
 /**
  * Validates the times in the event editor.
  * @param editor The editor to validate.
@@ -26,20 +28,21 @@ import {
 function validateTimes(
     editor: UseEventEditorResponse,
     errors: Record<string, string>,
+    t: TranslateFn,
     minEnd?: DateTime | null,
 ) {
     if (editor.start === null) {
-        errors.start = 'This field is required';
+        errors.start = t('validationRequired');
     } else if (!editor.start.isValid) {
-        errors.start = 'Start time must be a valid time';
+        errors.start = t('validationStartInvalid');
     }
 
     if (editor.end === null) {
-        errors.end = 'This field is required';
+        errors.end = t('validationRequired');
     } else if (!editor.end.isValid) {
-        errors.end = 'End time must be a valid time';
+        errors.end = t('validationEndInvalid');
     } else if (minEnd && editor.end < minEnd) {
-        errors.end = 'End time must be at least one hour after start time';
+        errors.end = t('validationEndTooEarly');
     }
 }
 
@@ -53,12 +56,13 @@ function requireField(
     editor: UseEventEditorResponse,
     field: keyof UseEventEditorResponse,
     errors: Record<string, string>,
+    t: TranslateFn,
 ) {
     const value = editor[field];
     if (typeof value === 'string' && !value.trim()) {
-        errors[field] = 'This field is required';
+        errors[field] = t('validationRequired');
     } else if (typeof value === 'number' && value < 0) {
-        errors[field] = 'This field is required';
+        errors[field] = t('validationRequired');
     }
 }
 
@@ -71,15 +75,16 @@ function requireField(
 function requireMaxParticipants(
     editor: UseEventEditorResponse,
     errors: Record<string, string>,
+    t: TranslateFn,
 ): number {
     if (!editor.maxParticipants.trim()) {
-        errors.maxParticipants = 'This field is required';
+        errors.maxParticipants = t('validationRequired');
         return -1;
     }
 
     const maxParticipants = parseFloat(editor.maxParticipants);
     if (isNaN(maxParticipants) || !Number.isInteger(maxParticipants) || maxParticipants < 1) {
-        errors.maxParticipants = 'You must specify an integer greater than 0';
+        errors.maxParticipants = t('validationIntegerRequired');
         return -1;
     }
 
@@ -97,13 +102,14 @@ function requirePrice(
     editor: UseEventEditorResponse,
     field: 'fullPrice' | 'currentPrice',
     errors: Record<string, string>,
+    t: TranslateFn,
 ): number {
     if (!editor[field].trim()) {
-        errors[field] = 'This field is required';
+        errors[field] = t('validationRequired');
         return -1;
     }
 
-    return optionalPrice(editor, field, errors);
+    return optionalPrice(editor, field, errors, t);
 }
 
 /**
@@ -117,6 +123,7 @@ function optionalPrice(
     editor: UseEventEditorResponse,
     field: 'fullPrice' | 'currentPrice',
     errors: Record<string, string>,
+    t: TranslateFn,
 ): number {
     if (!editor[field].trim()) {
         return -1;
@@ -124,15 +131,15 @@ function optionalPrice(
 
     const price = 100 * parseFloat(editor[field].trim());
     if (isNaN(price)) {
-        errors[field] = 'You must specify a number';
+        errors[field] = t('validationNumberRequired');
         return -1;
     }
     if (!Number.isInteger(price)) {
-        errors[field] = 'You must specify a valid dollar amount with up to 2 decimal places';
+        errors[field] = t('validationDollarAmount');
         return -1;
     }
     if (price < 500) {
-        errors[field] = 'Price must be at least $5';
+        errors[field] = t('validationMinPrice');
         return -1;
     }
     return price;
@@ -157,6 +164,7 @@ function validateRrule(
     editor: UseEventEditorResponse,
     timezoneOverride: string,
     errors: Record<string, string>,
+    t: TranslateFn,
 ): string {
     if (!editor.rruleOptions.freq || !editor.start) {
         return '';
@@ -170,7 +178,7 @@ function validateRrule(
     if (editor.rruleOptions.ends === RRuleEnds.Count) {
         options.count = editor.rruleOptions.count ?? getDefaultRRuleCount(editor.rruleOptions.freq);
         if (options.count <= 0) {
-            errors.count = 'Must be greater than 0';
+            errors.count = t('validationCountPositive');
         }
     }
 
@@ -206,16 +214,17 @@ function validateClassEditor(
     user: User,
     originalEvent: ProcessedEvent | undefined,
     editor: UseEventEditorResponse,
+    t: TranslateFn,
 ): [Event | null, Record<string, string>] {
     const errors: Record<string, string> = {};
 
-    validateTimes(editor, errors);
-    requireField(editor, 'title', errors);
-    requireField(editor, 'description', errors);
-    requireField(editor, 'location', errors);
-    const fullPrice = optionalPrice(editor, 'fullPrice', errors);
-    const currentPrice = optionalPrice(editor, 'currentPrice', errors);
-    const rrule = validateRrule(editor, user.timezoneOverride, errors);
+    validateTimes(editor, errors, t);
+    requireField(editor, 'title', errors, t);
+    requireField(editor, 'description', errors, t);
+    requireField(editor, 'location', errors, t);
+    const fullPrice = optionalPrice(editor, 'fullPrice', errors, t);
+    const currentPrice = optionalPrice(editor, 'currentPrice', errors, t);
+    const rrule = validateRrule(editor, user.timezoneOverride, errors, t);
 
     if (Object.entries(errors).length > 0) {
         return [null, errors];
@@ -273,18 +282,19 @@ function validateCoachingEditor(
     user: User,
     originalEvent: ProcessedEvent | undefined,
     editor: UseEventEditorResponse,
+    t: TranslateFn,
 ): [Event | null, Record<string, string>] {
     const errors: Record<string, string> = {};
 
-    validateTimes(editor, errors);
-    requireField(editor, 'title', errors);
-    requireField(editor, 'description', errors);
-    requireField(editor, 'location', errors);
+    validateTimes(editor, errors, t);
+    requireField(editor, 'title', errors, t);
+    requireField(editor, 'description', errors, t);
+    requireField(editor, 'location', errors, t);
 
-    const fullPrice = requirePrice(editor, 'fullPrice', errors);
-    const currentPrice = optionalPrice(editor, 'currentPrice', errors);
-    const maxParticipants = requireMaxParticipants(editor, errors);
-    const rrule = validateRrule(editor, user.timezoneOverride, errors);
+    const fullPrice = requirePrice(editor, 'fullPrice', errors, t);
+    const currentPrice = optionalPrice(editor, 'currentPrice', errors, t);
+    const maxParticipants = requireMaxParticipants(editor, errors, t);
+    const rrule = validateRrule(editor, user.timezoneOverride, errors, t);
 
     if (Object.entries(errors).length > 0) {
         return [null, errors];
@@ -344,12 +354,13 @@ function validateDojoEventEditor(
     user: User,
     originalEvent: ProcessedEvent | undefined,
     editor: UseEventEditorResponse,
+    t: TranslateFn,
 ): [Event | null, Record<string, string>] {
     const errors: Record<string, string> = {};
 
-    validateTimes(editor, errors);
-    requireField(editor, 'title', errors);
-    const rrule = validateRrule(editor, user.timezoneOverride, errors);
+    validateTimes(editor, errors, t);
+    requireField(editor, 'title', errors, t);
+    const rrule = validateRrule(editor, user.timezoneOverride, errors, t);
 
     if (Object.entries(errors).length > 0) {
         return [null, errors];
@@ -432,26 +443,27 @@ function validateAvailabilityEditor(
     user: User,
     originalEvent: ProcessedEvent | undefined,
     editor: UseEventEditorResponse,
+    t: TranslateFn,
 ): [Event | null, Record<string, string>] {
     const errors: Record<string, string> = {};
     const minEnd = getMinEnd(editor.start);
 
-    validateTimes(editor, errors, minEnd);
+    validateTimes(editor, errors, t, minEnd);
 
     const selectedTypes: AvailabilityType[] = editor.allAvailabilityTypes
         ? Object.values(AvailabilityTypes)
         : (Object.keys(editor.availabilityTypes).filter(
-              (t) => editor.availabilityTypes[t as AvailabilityType],
+              (at) => editor.availabilityTypes[at as AvailabilityType],
           ) as AvailabilityType[]);
     if (selectedTypes.length === 0) {
-        errors.types = 'At least one type is required';
+        errors.types = t('validationTypeRequired');
     }
     const cohorts = selectedCohorts(editor);
     if (!editor.inviteOnly && cohorts.length === 0) {
-        errors.cohorts = 'At least one cohort is required';
+        errors.cohorts = t('validationCohortRequired');
     }
     if (editor.inviteOnly && editor.invited.length === 0) {
-        errors.invited = 'At least one user is required when the event is invite-only';
+        errors.invited = t('validationInviteRequired');
     }
 
     let maxParticipants = getDefaultMaxParticipants(
@@ -459,7 +471,7 @@ function validateAvailabilityEditor(
         editor.availabilityTypes,
     );
     if (editor.maxParticipants !== '') {
-        maxParticipants = requireMaxParticipants(editor, errors);
+        maxParticipants = requireMaxParticipants(editor, errors, t);
     }
 
     if (Object.entries(errors).length > 0) {
@@ -516,16 +528,17 @@ export function validateEventEditor(
     user: User,
     originalEvent: ProcessedEvent | undefined,
     editor: UseEventEditorResponse,
+    t: TranslateFn,
 ): [Event | null, Record<string, string>] {
     switch (editor.type) {
         case EventType.Availability:
-            return validateAvailabilityEditor(user, originalEvent, editor);
+            return validateAvailabilityEditor(user, originalEvent, editor, t);
         case EventType.Dojo:
-            return validateDojoEventEditor(user, originalEvent, editor);
+            return validateDojoEventEditor(user, originalEvent, editor, t);
         case EventType.Coaching:
-            return validateCoachingEditor(user, originalEvent, editor);
+            return validateCoachingEditor(user, originalEvent, editor, t);
         case EventType.LectureTier:
         case EventType.GameReviewTier:
-            return validateClassEditor(user, originalEvent, editor);
+            return validateClassEditor(user, originalEvent, editor, t);
     }
 }

--- a/frontend/src/components/games/list/DownloadGamesDialog.tsx
+++ b/frontend/src/components/games/list/DownloadGamesDialog.tsx
@@ -81,9 +81,9 @@ export function DownloadGamesDialog({
                     });
             }, delay);
         } else if (retries >= MAX_RETRIES) {
-            onFailure('Request timed out');
+            onFailure(t('requestTimedOut'));
         }
-    }, [api, onFailure, startRequest.data, onSuccess, retries, setRetries, delay, setDelay]);
+    }, [api, onFailure, startRequest.data, onSuccess, retries, setRetries, delay, setDelay, t]);
 
     const onDownload = async () => {
         try {

--- a/frontend/src/components/newsfeed/NewsfeedItem.tsx
+++ b/frontend/src/components/newsfeed/NewsfeedItem.tsx
@@ -81,6 +81,7 @@ const NewsfeedItem: React.FC<NewsfeedItemProps> = ({
 
 const NewsfeedItemBody: React.FC<Omit<NewsfeedItemProps, 'onEdit'>> = ({ entry }) => {
     const t = useTranslations('newsfeed');
+    const tCommon = useTranslations('common');
     const { requirement } = useRequirement(entry.requirementId);
     if (entry.requirementId === TimelineSpecialRequirementId.Graduation) {
         return <GraduationNewsfeedItem entry={entry} />;
@@ -124,10 +125,10 @@ const NewsfeedItemBody: React.FC<Omit<NewsfeedItemProps, 'onEdit'>> = ({ entry }
                         {t('totalTime')}
                     </Typography>
                     <Typography>
-                        {formatTime(entry.totalMinutesSpent - entry.minutesSpent)}
+                        {formatTime(entry.totalMinutesSpent - entry.minutesSpent, tCommon)}
                     </Typography>
                     <ArrowRightAltIcon sx={{ color: 'text.secondary' }} />
-                    <Typography>{formatTime(entry.totalMinutesSpent)}</Typography>
+                    <Typography>{formatTime(entry.totalMinutesSpent, tCommon)}</Typography>
                 </Stack>
             )}
 

--- a/frontend/src/components/notifications/NotificationDescription.tsx
+++ b/frontend/src/components/notifications/NotificationDescription.tsx
@@ -5,6 +5,7 @@ import {
     NotificationTypes,
 } from '@jackstenglein/chess-dojo-common/src/database/notification';
 import { Stack, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 
 interface NotificationDescriptionProps {
     notification: Notification;
@@ -25,13 +26,14 @@ const DefaultNotificationDescription: React.FC<NotificationDescriptionProps> = (
     notification,
     menuItem,
 }) => {
+    const t = useTranslations('notifications');
     return (
         <Stack>
             <Typography variant='subtitle1' fontWeight='bold' noWrap={menuItem}>
-                {getTitle(notification)}
+                {getTitle(notification, t)}
             </Typography>
             <Typography color='text.secondary' noWrap={menuItem}>
-                {getDescription(notification)}
+                {getDescription(notification, t)}
             </Typography>
         </Stack>
     );
@@ -41,10 +43,11 @@ const NewFollowerNotificationDescription: React.FC<NotificationDescriptionProps>
     notification,
     menuItem,
 }) => {
+    const t = useTranslations('notifications');
     return (
         <Stack>
             <Typography variant='subtitle1' fontWeight='bold' noWrap={menuItem}>
-                {getTitle(notification)}
+                {getTitle(notification, t)}
             </Typography>
             <Stack direction='row' spacing={1} alignItems='center'>
                 <Avatar

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
@@ -77,7 +77,7 @@ export function EditTimelinEntryDialog({
                 deleted: [entry],
             });
             onDeleteEntry(entry);
-            deleteRequest.onSuccess('Rest day cleared');
+            deleteRequest.onSuccess(t('restDayCleared'));
             onClose();
         } catch (err) {
             deleteRequest.onFailure(err);

--- a/frontend/src/components/profile/directories/DirectoriesSection.tsx
+++ b/frontend/src/components/profile/directories/DirectoriesSection.tsx
@@ -47,7 +47,7 @@ import { BulkItemEditor } from './BulkItemEditor';
 import { ContextMenu } from './ContextMenu';
 import { DirectoryBreadcrumbs } from './DirectoryBreadcrumbs';
 import { useDirectory } from './DirectoryCache';
-import { adminColumns, DirectoryCreatedAt, publicColumns } from './DirectoryGridColumns';
+import { DirectoryCreatedAt, getAdminColumns, getPublicColumns } from './DirectoryGridColumns';
 import { ShareButton } from './share/ShareButton';
 import { StatsButton } from './stats/StatsButton';
 
@@ -104,6 +104,7 @@ const DirectorySection = ({
     sx,
 }: DirectoriesSectionProps) => {
     const api = useApi();
+    const tDir = useTranslations('profile.directories');
     const { searchParams, updateSearchParams } = useNextSearchParams({
         directory: 'home',
     });
@@ -282,7 +283,7 @@ const DirectorySection = ({
                     listViewColumn={listViewColDef}
                     listView={isMobile}
                     rows={rows}
-                    columns={isAdmin ? adminColumns : publicColumns}
+                    columns={isAdmin ? getAdminColumns(tDir) : getPublicColumns(tDir)}
                     columnVisibilityModel={columnVisibility}
                     onColumnVisibilityModelChange={(model) => setColumnVisibility(model)}
                     onColumnOrderChange={() => {

--- a/frontend/src/components/profile/directories/DirectoryGridColumns.tsx
+++ b/frontend/src/components/profile/directories/DirectoryGridColumns.tsx
@@ -17,244 +17,253 @@ import { Badge, Stack, Tooltip, Typography } from '@mui/material';
 import { GridColDef, GridRenderCellParams } from '@mui/x-data-grid-pro';
 import { useTranslations } from 'next-intl';
 
-export const publicColumns: GridColDef<DirectoryItem>[] = [
-    {
-        field: 'type',
-        headerName: 'Type',
-        valueGetter(_value, row) {
-            if (row.type === DirectoryItemTypes.DIRECTORY) {
-                return -1;
-            }
-            if (row.metadata.cohort === MastersCohort) {
-                return 2500;
-            }
-            return parseInt(row.metadata.cohort);
-        },
-        renderCell(params: GridRenderCellParams<DirectoryItem, DirectoryItemType>) {
-            const item = params.row;
+export function getPublicColumns(t: (key: string) => string): GridColDef<DirectoryItem>[] {
+    return [
+        {
+            field: 'type',
+            headerName: t('columnType'),
+            valueGetter(_value, row) {
+                if (row.type === DirectoryItemTypes.DIRECTORY) {
+                    return -1;
+                }
+                if (row.metadata.cohort === MastersCohort) {
+                    return 2500;
+                }
+                return parseInt(row.metadata.cohort);
+            },
+            renderCell(params: GridRenderCellParams<DirectoryItem, DirectoryItemType>) {
+                const item = params.row;
 
-            if (item.type === DirectoryItemTypes.DIRECTORY) {
+                if (item.type === DirectoryItemTypes.DIRECTORY) {
+                    return (
+                        <Badge
+                            badgeContent={item.metadata.gameCount || 0}
+                            color='secondary'
+                            sx={{
+                                '& .MuiBadge-badge': {
+                                    fontSize: '0.65rem',
+                                    minWidth: 16,
+                                    height: 16,
+                                },
+                            }}
+                            showZero
+                            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                            overlap='circular'
+                        >
+                            <Folder sx={{ height: 1 }} />
+                        </Badge>
+                    );
+                }
+
+                let value = item.metadata.cohort;
+                if (value && value !== dojoCohorts[0] && value !== dojoCohorts.slice(-1)[0]) {
+                    value = value.replace('00', '');
+                }
+
                 return (
-                    <Badge
-                        badgeContent={item.metadata.gameCount || 0}
-                        color='secondary'
-                        sx={{
-                            '& .MuiBadge-badge': { fontSize: '0.65rem', minWidth: 16, height: 16 },
-                        }}
-                        showZero
-                        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-                        overlap='circular'
-                    >
-                        <Folder sx={{ height: 1 }} />
-                    </Badge>
-                );
-            }
-
-            let value = item.metadata.cohort;
-            if (value && value !== dojoCohorts[0] && value !== dojoCohorts.slice(-1)[0]) {
-                value = value.replace('00', '');
-            }
-
-            return (
-                <Stack sx={{ height: 1 }} alignItems='center' justifyContent='center'>
-                    <CohortIcon
-                        cohort={item.metadata.cohort}
-                        tooltip={item.metadata.cohort}
-                        size={30}
-                    />
-                    <Typography variant='caption' sx={{ fontSize: '0.65rem' }}>
-                        {item.metadata.cohort === MastersCohort ? 'masters' : value}
-                    </Typography>
-                </Stack>
-            );
-        },
-        align: 'center',
-        headerAlign: 'center',
-        width: 52,
-        disableColumnMenu: true,
-        resizable: false,
-    },
-    {
-        field: 'name',
-        headerName: 'Name',
-        valueGetter: (_value, row) => {
-            switch (row.type) {
-                case DirectoryItemTypes.DIRECTORY:
-                    return row.metadata.name;
-            }
-            return `${row.metadata.white} ${row.metadata.black}`;
-        },
-        renderCell: (params: GridRenderCellParams<DirectoryItem, string>) => {
-            const item = params.row;
-            if (item.type === DirectoryItemTypes.DIRECTORY) {
-                return (
-                    <Stack sx={{ height: 1, justifyContent: 'center', rowGap: '2px' }}>
-                        <Link color='inherit' sx={{ cursor: 'pointer', lineHeight: 'initial' }}>
-                            {params.value}
-                        </Link>
-                        {item.metadata.description && (
-                            <Typography
-                                variant='caption'
-                                color='text.secondary'
-                                sx={{
-                                    lineHeight: 'initial',
-                                    whiteSpace: 'nowrap',
-                                    textOverflow: 'ellipsis',
-                                    overflow: 'hidden',
-                                }}
-                            >
-                                {item.metadata.description}
-                            </Typography>
-                        )}
+                    <Stack sx={{ height: 1 }} alignItems='center' justifyContent='center'>
+                        <CohortIcon
+                            cohort={item.metadata.cohort}
+                            tooltip={item.metadata.cohort}
+                            size={30}
+                        />
+                        <Typography variant='caption' sx={{ fontSize: '0.65rem' }}>
+                            {item.metadata.cohort === MastersCohort ? 'masters' : value}
+                        </Typography>
                     </Stack>
                 );
-            }
+            },
+            align: 'center',
+            headerAlign: 'center',
+            width: 52,
+            disableColumnMenu: true,
+            resizable: false,
+        },
+        {
+            field: 'name',
+            headerName: t('columnName'),
+            valueGetter: (_value, row) => {
+                switch (row.type) {
+                    case DirectoryItemTypes.DIRECTORY:
+                        return row.metadata.name;
+                }
+                return `${row.metadata.white} ${row.metadata.black}`;
+            },
+            renderCell: (params: GridRenderCellParams<DirectoryItem, string>) => {
+                const item = params.row;
+                if (item.type === DirectoryItemTypes.DIRECTORY) {
+                    return (
+                        <Stack sx={{ height: 1, justifyContent: 'center', rowGap: '2px' }}>
+                            <Link color='inherit' sx={{ cursor: 'pointer', lineHeight: 'initial' }}>
+                                {params.value}
+                            </Link>
+                            {item.metadata.description && (
+                                <Typography
+                                    variant='caption'
+                                    color='text.secondary'
+                                    sx={{
+                                        lineHeight: 'initial',
+                                        whiteSpace: 'nowrap',
+                                        textOverflow: 'ellipsis',
+                                        overflow: 'hidden',
+                                    }}
+                                >
+                                    {item.metadata.description}
+                                </Typography>
+                            )}
+                        </Stack>
+                    );
+                }
 
-            return RenderPlayers({ ...item.metadata, fullHeight: true });
+                return RenderPlayers({ ...item.metadata, fullHeight: true });
+            },
+            flex: 1,
         },
-        flex: 1,
-    },
-    {
-        field: 'result',
-        headerName: 'Result',
-        headerAlign: 'center',
-        valueGetter: (_value, row) => {
-            switch (row.type) {
-                case DirectoryItemTypes.DIRECTORY:
-                    return '';
-                default:
-                    return row.metadata.result;
-            }
+        {
+            field: 'result',
+            headerName: t('columnResult'),
+            headerAlign: 'center',
+            valueGetter: (_value, row) => {
+                switch (row.type) {
+                    case DirectoryItemTypes.DIRECTORY:
+                        return '';
+                    default:
+                        return row.metadata.result;
+                }
+            },
+            renderCell: (params) => {
+                if (params.row.type === DirectoryItemTypes.DIRECTORY) {
+                    return null;
+                }
+                return <RenderGameResultStack result={params.row.metadata.result} />;
+            },
+            width: 50,
+            disableColumnMenu: true,
+            flex: 0.25,
         },
-        renderCell: (params) => {
-            if (params.row.type === DirectoryItemTypes.DIRECTORY) {
-                return null;
-            }
-            return <RenderGameResultStack result={params.row.metadata.result} />;
-        },
-        width: 50,
-        disableColumnMenu: true,
-        flex: 0.25,
-    },
-    {
-        field: 'owner',
-        headerName: 'Owner',
-        valueGetter: (_value, row) => {
-            switch (row.type) {
-                case DirectoryItemTypes.DIRECTORY:
-                    return '';
-                default:
-                    return row.metadata.owner;
-            }
-        },
-        renderCell: (params: GridRenderCellParams<DirectoryItem, string>) => {
-            const item = params.row;
-            if (
-                item.type === DirectoryItemTypes.DIRECTORY ||
-                item.metadata.ownerDisplayName === ''
-            ) {
-                return null;
-            }
+        {
+            field: 'owner',
+            headerName: t('columnOwner'),
+            valueGetter: (_value, row) => {
+                switch (row.type) {
+                    case DirectoryItemTypes.DIRECTORY:
+                        return '';
+                    default:
+                        return row.metadata.owner;
+                }
+            },
+            renderCell: (params: GridRenderCellParams<DirectoryItem, string>) => {
+                const item = params.row;
+                if (
+                    item.type === DirectoryItemTypes.DIRECTORY ||
+                    item.metadata.ownerDisplayName === ''
+                ) {
+                    return null;
+                }
 
-            if (item.metadata.ownerDisplayName === MastersOwnerDisplayName) {
-                return MastersOwnerDisplayName;
-            }
+                if (item.metadata.ownerDisplayName === MastersOwnerDisplayName) {
+                    return MastersOwnerDisplayName;
+                }
 
-            return (
-                <Stack
-                    direction='row'
-                    spacing={1}
-                    alignItems='center'
-                    onClick={(e) => e.stopPropagation()}
-                >
-                    <Avatar
-                        username={item.metadata.owner}
-                        displayName={item.metadata.ownerDisplayName}
-                        size={32}
-                    />
-                    <Link href={`/profile/${item.metadata.owner}`}>
-                        {item.metadata.ownerDisplayName}
-                    </Link>
-                </Stack>
-            );
-        },
-        flex: 0.5,
-    },
-    {
-        field: 'date',
-        headerName: 'Date Played',
-        valueGetter: (_value, row) => {
-            if (row.type === DirectoryItemTypes.DIRECTORY) {
-                return '';
-            }
-            return row.metadata.date ?? '';
-        },
-        width: 110,
-        align: 'center',
-        headerAlign: 'center',
-    },
-    {
-        field: 'createdAt',
-        headerName: 'Date Created',
-        valueGetter: (_value, row) => row.metadata.createdAt,
-        renderCell(params: GridRenderCellParams<DirectoryItem, string>) {
-            return <DirectoryCreatedAt createdAt={params.value} />;
-        },
-        width: 110,
-        align: 'center',
-    },
-];
-
-export const adminColumns: GridColDef<DirectoryItem>[] = [
-    ...publicColumns.slice(0, 2),
-    {
-        field: 'visibility',
-        headerName: 'Visibility',
-        headerAlign: 'center',
-        valueGetter: (_value, row) => {
-            switch (row.type) {
-                case DirectoryItemTypes.DIRECTORY:
-                    return row.metadata.visibility;
-                default:
-                    return row.metadata.unlisted
-                        ? DirectoryVisibility.PRIVATE
-                        : DirectoryVisibility.PUBLIC;
-            }
-        },
-        renderCell: (params) => {
-            let isPublic = false;
-            if (params.row.type === DirectoryItemTypes.DIRECTORY) {
-                isPublic = params.row.metadata.visibility === DirectoryVisibility.PUBLIC;
-            } else {
-                isPublic = !params.row.metadata.unlisted;
-            }
-
-            return (
-                <Stack width={1} height={1} alignItems='center' justifyContent='center'>
-                    <Tooltip
-                        title={
-                            isPublic
-                                ? 'Public'
-                                : params.row.type === DirectoryItemTypes.DIRECTORY
-                                  ? 'Private'
-                                  : 'Unlisted'
-                        }
+                return (
+                    <Stack
+                        direction='row'
+                        spacing={1}
+                        alignItems='center'
+                        onClick={(e) => e.stopPropagation()}
                     >
-                        {isPublic ? (
-                            <Visibility sx={{ color: 'text.secondary' }} />
-                        ) : (
-                            <VisibilityOff sx={{ color: 'text.secondary' }} />
-                        )}
-                    </Tooltip>
-                </Stack>
-            );
+                        <Avatar
+                            username={item.metadata.owner}
+                            displayName={item.metadata.ownerDisplayName}
+                            size={32}
+                        />
+                        <Link href={`/profile/${item.metadata.owner}`}>
+                            {item.metadata.ownerDisplayName}
+                        </Link>
+                    </Stack>
+                );
+            },
+            flex: 0.5,
         },
-        width: 50,
-        disableColumnMenu: true,
-        flex: 0.25,
-    },
-    ...publicColumns.slice(2),
-];
+        {
+            field: 'date',
+            headerName: t('columnDatePlayed'),
+            valueGetter: (_value, row) => {
+                if (row.type === DirectoryItemTypes.DIRECTORY) {
+                    return '';
+                }
+                return row.metadata.date ?? '';
+            },
+            width: 110,
+            align: 'center',
+            headerAlign: 'center',
+        },
+        {
+            field: 'createdAt',
+            headerName: t('columnDateCreated'),
+            valueGetter: (_value, row) => row.metadata.createdAt,
+            renderCell(params: GridRenderCellParams<DirectoryItem, string>) {
+                return <DirectoryCreatedAt createdAt={params.value} />;
+            },
+            width: 110,
+            align: 'center',
+        },
+    ];
+}
+
+export function getAdminColumns(t: (key: string) => string): GridColDef<DirectoryItem>[] {
+    const cols = getPublicColumns(t);
+    return [
+        ...cols.slice(0, 2),
+        {
+            field: 'visibility',
+            headerName: t('columnVisibility'),
+            headerAlign: 'center',
+            valueGetter: (_value, row) => {
+                switch (row.type) {
+                    case DirectoryItemTypes.DIRECTORY:
+                        return row.metadata.visibility;
+                    default:
+                        return row.metadata.unlisted
+                            ? DirectoryVisibility.PRIVATE
+                            : DirectoryVisibility.PUBLIC;
+                }
+            },
+            renderCell: (params) => {
+                let isPublic = false;
+                if (params.row.type === DirectoryItemTypes.DIRECTORY) {
+                    isPublic = params.row.metadata.visibility === DirectoryVisibility.PUBLIC;
+                } else {
+                    isPublic = !params.row.metadata.unlisted;
+                }
+
+                return (
+                    <Stack width={1} height={1} alignItems='center' justifyContent='center'>
+                        <Tooltip
+                            title={
+                                isPublic
+                                    ? t('public')
+                                    : params.row.type === DirectoryItemTypes.DIRECTORY
+                                      ? t('private')
+                                      : t('unlisted')
+                            }
+                        >
+                            {isPublic ? (
+                                <Visibility sx={{ color: 'text.secondary' }} />
+                            ) : (
+                                <VisibilityOff sx={{ color: 'text.secondary' }} />
+                            )}
+                        </Tooltip>
+                    </Stack>
+                );
+            },
+            width: 50,
+            disableColumnMenu: true,
+            flex: 0.25,
+        },
+        ...cols.slice(2),
+    ];
+}
 
 export function DirectoryCreatedAt({ createdAt }: { createdAt?: string }) {
     const { user } = useAuth();

--- a/frontend/src/components/profile/info/Heatmap.tsx
+++ b/frontend/src/components/profile/info/Heatmap.tsx
@@ -172,6 +172,7 @@ export function Heatmap({
     };
 }) {
     const t = useTranslations('profile.info.heatmap');
+    const tCommon = useTranslations('common');
     const isLight = useLightMode();
     const { user: viewer } = useAuth();
     const api = useApi();
@@ -437,7 +438,7 @@ export function Heatmap({
                               description,
                           })
                         : t('totalMinutesLine', {
-                              time: formatTime(totalMinutesSpent),
+                              time: formatTime(totalMinutesSpent, tCommon),
                               description,
                           })}
                 </Typography>
@@ -892,6 +893,7 @@ function BlockTooltip({
     field: TimelineEntryField;
 }) {
     const t = useTranslations('profile.info.heatmap');
+    const tCommon = useTranslations('common');
     const categories = Object.entries(activity.categoryCounts ?? {})
         .filter((entry) => VALID_TOOLTIP_CATEGORIES.includes(entry[0] as RequirementCategory))
         .sort(
@@ -911,7 +913,7 @@ function BlockTooltip({
                           date: activity.date,
                       })
                     : t('minutesOnDate', {
-                          time: formatTime(activity.minutesSpent || 0),
+                          time: formatTime(activity.minutesSpent || 0, tCommon),
                           date: activity.date,
                       })}
             </Typography>
@@ -1012,6 +1014,7 @@ function WeekSummaryTooltip({
     inProgress: boolean;
 }) {
     const t = useTranslations('profile.info.heatmap');
+    const tCommon = useTranslations('common');
     const startDate = new Date(weekSummary.date);
     startDate.setDate(startDate.getDate() - 6);
     const startDateStr = `${startDate.getUTCFullYear()}-${`${startDate.getUTCMonth() + 1}`.padStart(2, '0')}-${`${startDate.getUTCDate()}`.padStart(2, '0')}`;
@@ -1069,7 +1072,8 @@ function WeekSummaryTooltip({
                 </Stack>
 
                 <Typography variant='caption' pt='2px'>
-                    {formatTime(weekSummary.minutesSpent)} / {formatTime(goalMinutes)}
+                    {formatTime(weekSummary.minutesSpent, tCommon)} /{' '}
+                    {formatTime(goalMinutes, tCommon)}
                 </Typography>
             </Stack>
 
@@ -1164,6 +1168,7 @@ function TooltipRow({
     striped?: boolean;
 }) {
     const t = useTranslations('profile.info.heatmap');
+    const tCommon = useTranslations('common');
     return (
         <Stack
             direction='row'
@@ -1202,7 +1207,7 @@ function TooltipRow({
                           points: Math.round(10 * count) / 10,
                           pluralCount: count,
                       })
-                    : formatTime(count)}
+                    : formatTime(count, tCommon)}
             </Typography>
         </Stack>
     );
@@ -1228,9 +1233,12 @@ function LegendTooltip({
     field: TimelineEntryField;
 }) {
     const t = useTranslations('profile.info.heatmap');
+    const tCommon = useTranslations('common');
     const minValue = Math.max(0, (clamp / (MAX_LEVEL - 1)) * (level - 1));
     const baseValue =
-        field === 'minutesSpent' ? formatTime(minValue) : `${Math.round(minValue * 100) / 100}`;
+        field === 'minutesSpent'
+            ? formatTime(minValue, tCommon)
+            : `${Math.round(minValue * 100) / 100}`;
 
     let value: string;
     if (level === 0) {
@@ -1242,7 +1250,7 @@ function LegendTooltip({
             field === 'minutesSpent'
                 ? t('legendMinutesRange', {
                       minValue: baseValue,
-                      maxValue: formatTime(maxValue),
+                      maxValue: formatTime(maxValue, tCommon),
                   })
                 : t('legendDojoPointsRange', {
                       minValue: baseValue,

--- a/frontend/src/components/profile/trainingPlan/ProgressHistory.tsx
+++ b/frontend/src/components/profile/trainingPlan/ProgressHistory.tsx
@@ -218,7 +218,7 @@ export const ProgressHistoryItem = ({
                 <Tooltip title={t('deleteEntry')}>
                     <IconButton
                         data-testid='task-history-delete-button'
-                        aria-label='delete'
+                        aria-label={t('deleteAriaLabel')}
                         onClick={deleteItem}
                     >
                         <DeleteIcon />

--- a/frontend/src/components/profile/trainingPlan/TimeProgressChip.tsx
+++ b/frontend/src/components/profile/trainingPlan/TimeProgressChip.tsx
@@ -1,5 +1,6 @@
 import { formatTime } from '@/database/requirement';
 import { alpha, Box, BoxProps, Chip, ChipProps } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import { RefObject } from 'react';
 
 interface TimeProgressChipProps {
@@ -27,6 +28,7 @@ interface TimeProgressChipProps {
  * @param value The current time completed for the chip.
  */
 export function TimeProgressChip({ goal, value, slotProps, ref, ...rest }: TimeProgressChipProps) {
+    const tCommon = useTranslations('common');
     const percentage = Math.min(100, goal > 0 ? (100 * value) / goal : 100);
     const color = percentage < 50 ? 'error' : percentage < 100 ? 'warning' : 'success';
 
@@ -49,7 +51,7 @@ export function TimeProgressChip({ goal, value, slotProps, ref, ...rest }: TimeP
             />
             <Chip
                 variant='outlined'
-                label={`${formatTime(value)} / ${formatTime(goal)}`}
+                label={`${formatTime(value, tCommon)} / ${formatTime(goal, tCommon)}`}
                 {...slotProps?.chip}
                 sx={{
                     borderColor: (theme) => alpha(theme.palette[color].main, 0.6),

--- a/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/daily/DailyTrainingPlan.tsx
@@ -218,6 +218,7 @@ function DailyTrainingPlanItem({
 }) {
     const t = useTranslations('profile.trainingPlan.daily');
     const tCommon = useTranslations('profile.trainingPlan.common');
+    const tTime = useTranslations('common');
     const { task } = suggestion;
     const { isCurrentUser, pinnedTasks, togglePin, timeline, user, toggleSkip } =
         use(TrainingPlanContext);
@@ -259,7 +260,12 @@ function DailyTrainingPlanItem({
                                 />
 
                                 <Typography variant='h6' fontWeight='bold'>
-                                    {taskTitle({ task, cohort: user.dojoCohort, goalMinutes })}
+                                    {taskTitle({
+                                        task,
+                                        cohort: user.dojoCohort,
+                                        goalMinutes,
+                                        tCommon: tTime,
+                                    })}
                                 </Typography>
                             </Stack>
 
@@ -383,20 +389,22 @@ export function taskTitle({
     task,
     cohort,
     goalMinutes,
+    tCommon,
 }: {
     task: Requirement | CustomTask;
     cohort: string;
     goalMinutes: number;
+    tCommon: (key: string, values?: Record<string, string | number>) => string;
 }) {
     const totalCount = getTotalCount(cohort, task, true);
 
     let title = goalMinutes > 0 ? task.dailyName : task.name;
     title = (title || task.name)
         .replaceAll('{{count}}', `${totalCount}`)
-        .replaceAll('{{time}}', formatTime(goalMinutes));
+        .replaceAll('{{time}}', formatTime(goalMinutes, tCommon));
 
     if (!isRequirement(task) && goalMinutes > 0) {
-        title += ` - ${formatTime(goalMinutes)}`;
+        title += ` - ${formatTime(goalMinutes, tCommon)}`;
     }
 
     return title;

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlan.tsx
@@ -48,13 +48,16 @@ import { TrainingPlanContext } from '../TrainingPlanTab';
 import { FullTrainingPlanSection, GRADUATION_TASK_ID, Section } from './FullTrainingPlanSection';
 
 /** Builds a minimal fake requirement for the "Graduate from {cohort}" task. */
-function getGraduationFakeTask(cohort: string): Requirement {
+function getGraduationFakeTask(
+    cohort: string,
+    t: (key: string, values?: Record<string, string>) => string,
+): Requirement {
     return {
         id: GRADUATION_TASK_ID,
         status: RequirementStatus.Active,
         category: RequirementCategory.Graduation,
-        name: `Graduate from ${cohort}`,
-        description: 'Move to the next cohort and get featured in the graduation show.',
+        name: t('graduateName', { cohort }),
+        description: t('graduateDescription'),
         freeDescription: '',
         counts: { [cohort]: 1 },
         startCount: 0,
@@ -147,7 +150,7 @@ export function FullTrainingPlan({
 
         // Add a Graduation section when viewing the user's current cohort (they can only graduate from it).
         if (cohort === user.dojoCohort) {
-            const graduationTask = getGraduationFakeTask(cohort);
+            const graduationTask = getGraduationFakeTask(cohort, t);
             const gradComplete = user.graduationCohorts?.includes(cohort) ?? false;
             const minBoundary = getMinRatingBoundary(cohort, user.ratingSystem);
             const graduationBoundary = getRatingBoundary(cohort, user.ratingSystem);
@@ -182,7 +185,7 @@ export function FullTrainingPlan({
         }
 
         return sections;
-    }, [allRequirements, user, cohort, timeline]);
+    }, [allRequirements, user, cohort, timeline, t]);
 
     if (requirementRequest.isLoading() || sections.length === 0) {
         return <LoadingPage />;

--- a/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanItem.tsx
+++ b/frontend/src/components/profile/trainingPlan/full/FullTrainingPlanItem.tsx
@@ -54,6 +54,7 @@ export const FullTrainingPlanItem = ({
 }: FullTrainingPlanItemProps) => {
     const t = useTranslations('profile.trainingPlan.full');
     const tCommon = useTranslations('profile.trainingPlan.common');
+    const tTime = useTranslations('common');
     const [taskDialogView, setTaskDialogView] = useState<TaskDialogView>();
     const { requirements } = useRequirements(ALL_COHORTS, false);
     const { entries } = useTimelineContext();
@@ -64,7 +65,7 @@ export const FullTrainingPlanItem = ({
 
     const totalCount = getTotalCount(cohort, requirement, true);
     const currentCount = getCurrentCount({ cohort, requirement, progress, timeline: entries });
-    const time = formatTime(getTotalTime(cohort, progress));
+    const time = formatTime(getTotalTime(cohort, progress), tTime);
     const expired = isExpired(requirement, progress);
     const isMinimumTask = MINIMUM_TASKS.has(requirement.id);
     const minimumReached = isMinimumTask && currentCount >= totalCount;
@@ -77,7 +78,7 @@ export const FullTrainingPlanItem = ({
             UpdateElement = (
                 <Tooltip title={tCommon('updateProgress')}>
                     <Checkbox
-                        aria-label={`Checkbox ${requirement.name}`}
+                        aria-label={t('checkboxAriaLabel', { name: requirement.name })}
                         checked={currentCount >= totalCount}
                         onClick={() => setTaskDialogView(TaskDialogView.Progress)}
                         disabled={!isCurrentUser}
@@ -102,7 +103,7 @@ export const FullTrainingPlanItem = ({
                 ) : !isCurrentUser ? null : (
                     <Tooltip title={tCommon('updateProgress')}>
                         <IconButton
-                            aria-label={`Update ${requirement.name}`}
+                            aria-label={t('updateAriaLabel', { name: requirement.name })}
                             onClick={() => setTaskDialogView(TaskDialogView.Progress)}
                             data-testid='update-task-button'
                         >

--- a/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
+++ b/frontend/src/components/profile/trainingPlan/weekly/WeeklyTrainingPlan.tsx
@@ -97,7 +97,7 @@ export function WeeklyTrainingPlan() {
 
             <Collapse in={expanded}>
                 <Stack spacing={2} mb={1}>
-                    <Tooltip title='Only show tasks you have updated this week' placement='right'>
+                    <Tooltip title={t('activeOnlyTooltip')} placement='right'>
                         <FormControlLabel
                             control={
                                 <Switch
@@ -108,7 +108,7 @@ export function WeeklyTrainingPlan() {
                             }
                             label={
                                 <Typography variant='body2' color='text.secondary'>
-                                    Active Only
+                                    {t('activeOnlyLabel')}
                                 </Typography>
                             }
                             sx={{ ml: 1, width: 'fit-content' }}
@@ -252,6 +252,7 @@ function WeeklyTrainingPlanItem({
     activeOnly: boolean;
 }) {
     const { task } = suggestion;
+    const tTime = useTranslations('common');
     const { isCurrentUser, user, timeline } = use(TrainingPlanContext);
     const tasks = useMemo(() => [suggestion], [suggestion]);
     const [goalMinutes, timeWorked, _, __, active] = useTrainingPlanProgress({
@@ -306,7 +307,7 @@ function WeeklyTrainingPlanItem({
             >
                 <Stack spacing={3} width={1}>
                     <Typography variant='body2' fontWeight='bold'>
-                        {taskTitle({ task, cohort: user.dojoCohort, goalMinutes })}
+                        {taskTitle({ task, cohort: user.dojoCohort, goalMinutes, tCommon: tTime })}
                     </Typography>
 
                     <Stack direction='row' flexWrap='wrap' gap={1}>

--- a/frontend/src/components/profile/yearReview/TimeSection.tsx
+++ b/frontend/src/components/profile/yearReview/TimeSection.tsx
@@ -9,18 +9,24 @@ import { Datum, getCategoryData, getMonthData, getTaskData, primaryAxis } from '
 import Percentiles from './Percentiles';
 import { SectionProps } from './section';
 
-const secondaryAxes: AxisOptions<Datum>[] = [
-    {
-        position: 'bottom',
-        getValue: (datum) => datum.secondary,
-        formatters: {
-            scale: formatTime,
+function getSecondaryAxes(
+    tCommon: (key: string, values?: Record<string, string | number>) => string,
+): AxisOptions<Datum>[] {
+    return [
+        {
+            position: 'bottom',
+            getValue: (datum) => datum.secondary,
+            formatters: {
+                scale: (value: number) => formatTime(value, tCommon),
+            },
         },
-    },
-];
+    ];
+}
 
 const TimeSection = ({ review }: SectionProps) => {
     const t = useTranslations('profile.yearReview.time');
+    const tCommon = useTranslations('common');
+    const secondaryAxes = useMemo(() => getSecondaryAxes(tCommon), [tCommon]);
     const viewer = useAuth().user;
     const dark = !viewer?.enableLightMode;
 
@@ -64,7 +70,7 @@ const TimeSection = ({ review }: SectionProps) => {
                                         fontWeight: 'bold',
                                     }}
                                 >
-                                    {formatTime(data.total.value)}
+                                    {formatTime(data.total.value, tCommon)}
                                 </Typography>
                             </Stack>
                         </Grid>

--- a/frontend/src/components/timer/TimerContext.tsx
+++ b/frontend/src/components/timer/TimerContext.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '@/auth/Auth';
 import { formatTime } from '@/board/pgn/boardTools/underboard/clock/ClockUsage';
 import { CustomTask, Requirement } from '@/database/requirement';
 import { User } from '@/database/user';
+import { useTranslations } from 'next-intl';
 import { createContext, ReactNode, useEffect, useState } from 'react';
 
 /** Regex which matches the timer in the title of the page */
@@ -33,12 +34,13 @@ export const TimerContext = createContext<Timer>(null as unknown as Timer);
  * between different components.
  */
 export function TimerContextProvider({ children }: { children: ReactNode }) {
+    const t = useTranslations('timer');
     const { user, updateUser } = useAuth();
     const api = useApi();
     const [timerSeconds, setTimerSeconds] = useState(() => getTimerSeconds(user));
     const [showTask, setShowTask] = useState(false);
     const { requirement } = useRequirement(user?.timerTaskId);
-    const customTask = user?.customTasks?.find((t) => t.id === user.timerTaskId);
+    const customTask = user?.customTasks?.find((ct) => ct.id === user.timerTaskId);
 
     const [isRunning, setIsRunning] = useState(Boolean(user?.timerStartedAt));
     const isPaused = !isRunning && Boolean(user?.timerSeconds);
@@ -91,15 +93,15 @@ export function TimerContextProvider({ children }: { children: ReactNode }) {
     const getLabel = (taskId?: string) => {
         if (!user?.timerTaskId || taskId === user?.timerTaskId) {
             if (isRunning) {
-                return `Pause Timer (${formatTime(timerSeconds)})`;
+                return t('pauseTimer', { time: formatTime(timerSeconds) });
             }
             if (user?.timerSeconds) {
-                return `Resume Timer (${formatTime(timerSeconds)})`;
+                return t('resumeTimer', { time: formatTime(timerSeconds) });
             }
-            return 'Start Timer';
+            return t('startTimer');
         }
 
-        return `Clear and Restart Timer`;
+        return t('clearAndRestart');
     };
 
     const onToggle = (taskId?: string) => {

--- a/frontend/src/components/tournaments/round-robin/Stats.tsx
+++ b/frontend/src/components/tournaments/round-robin/Stats.tsx
@@ -58,7 +58,7 @@ export function Stats({ tournament }: { tournament: RoundRobin }) {
                         newViewMode && setViewMode(newViewMode)
                     }
                     size='small'
-                    aria-label='view mode toggle'
+                    aria-label={t('viewModeAriaLabel')}
                 >
                     <ToggleButton value='count'>{t('viewCount')}</ToggleButton>
                     <ToggleButton value='percentage'>{t('viewPercentage')}</ToggleButton>
@@ -71,7 +71,7 @@ export function Stats({ tournament }: { tournament: RoundRobin }) {
                     onChange={(_e, newDisplayMode: 'graph' | 'list' | null) =>
                         newDisplayMode && setDisplayMode(newDisplayMode)
                     }
-                    aria-label='display mode toggle'
+                    aria-label={t('displayModeAriaLabel')}
                 >
                     <ToggleButton value='graph'>{t('displayGraph')}</ToggleButton>
                     <ToggleButton value='list'>{t('displayList')}</ToggleButton>

--- a/frontend/src/database/exam.ts
+++ b/frontend/src/database/exam.ts
@@ -7,13 +7,13 @@ export { ExamType } from '@jackstenglein/chess-dojo-common/src/database/exam';
  * @param type The type of the Exam.
  * @returns A display string for the Exam type.
  */
-export function displayExamType(type: ExamType): string {
+export function displayExamType(type: ExamType, t: (key: string) => string): string {
     switch (type) {
         case ExamType.Tactics:
-            return 'Tactics Test';
+            return t('tacticsTest');
         case ExamType.Polgar:
-            return 'Checkmate Test';
+            return t('checkmateTest');
         case ExamType.Endgame:
-            return 'Endgame Test';
+            return t('endgameTest');
     }
 }

--- a/frontend/src/database/game.ts
+++ b/frontend/src/database/game.ts
@@ -35,12 +35,15 @@ export function isDefaultHeader(header: string): boolean {
     );
 }
 
-export function displayGameReviewType(t: GameReviewType): string {
-    switch (t) {
+export function displayGameReviewType(
+    reviewType: GameReviewType,
+    t: (key: string) => string,
+): string {
+    switch (reviewType) {
         case GameReviewType.Quick:
-            return 'Quick';
+            return t('reviewTypeQuick');
         case GameReviewType.Deep:
-            return 'Deep Dive';
+            return t('reviewTypeDeepDive');
     }
 }
 export const MastersCohort = 'masters';

--- a/frontend/src/database/notification.ts
+++ b/frontend/src/database/notification.ts
@@ -6,12 +6,15 @@ import {
 
 export type { Notification };
 
+type TranslateFn = (key: string, values?: Record<string, string | number>) => string;
+
 /**
  * Returns the title for the given notification.
  * @param notification The notification to get the title for.
+ * @param t The translation function.
  * @returns The title for the given notification.
  */
-export function getTitle(notification: Notification): string {
+export function getTitle(notification: Notification, t: TranslateFn): string {
     switch (notification.type) {
         case NotificationTypes.GAME_COMMENT:
         case NotificationTypes.GAME_COMMENT_REPLY:
@@ -19,7 +22,7 @@ export function getTitle(notification: Notification): string {
         case NotificationTypes.GAME_REVIEW_COMPLETE:
             return `${notification.gameReviewMetadata?.headers.White} - ${notification.gameReviewMetadata?.headers.Black}`;
         case NotificationTypes.NEW_FOLLOWER:
-            return 'You have a new follower';
+            return t('newFollowerTitle');
         case NotificationTypes.TIMELINE_COMMENT:
         case NotificationTypes.TIMELINE_REACTION:
             return `${notification.timelineCommentMetadata?.name}`;
@@ -27,54 +30,55 @@ export function getTitle(notification: Notification): string {
             if (notification.count === 1) {
                 return `${notification.explorerGameMetadata?.[0].headers.White} - ${notification.explorerGameMetadata?.[0].headers.Black}`;
             }
-            return `${notification.count} new games were added with a position you follow.`;
+            return t('explorerGameTitle', { count: notification.count ?? 0 });
         case NotificationTypes.NEW_CLUB_JOIN_REQUEST:
             return `${notification.clubMetadata?.name}`;
         case NotificationTypes.CLUB_JOIN_REQUEST_APPROVED:
             return `${notification.clubMetadata?.name}`;
         case NotificationTypes.CALENDAR_INVITE:
-            return `You've been invited to an event on the calendar`;
+            return t('calendarInviteTitle');
         case NotificationTypes.ROUND_ROBIN_START:
-            return `Round robin ${notification.roundRobinStartMetadata?.cohort} ${notification.roundRobinStartMetadata?.name} has started`;
+            return t('roundRobinStartTitle', {
+                cohort: notification.roundRobinStartMetadata?.cohort ?? '',
+                name: notification.roundRobinStartMetadata?.name ?? '',
+            });
     }
 }
 
-export function getDescription(notification: Notification): string {
+export function getDescription(notification: Notification, t: TranslateFn): string {
     const count = notification.count || 1;
 
     switch (notification.type) {
         case NotificationTypes.GAME_COMMENT:
-            return 'There are new comments on your game.';
+            return t('gameCommentDescription');
         case NotificationTypes.GAME_COMMENT_REPLY:
-            return count === 1
-                ? `There is a new reply to a comment thread you participated in.`
-                : `There are ${count} new replies in comment threads you participated in.`;
+            return t('gameCommentReplyDescription', { count });
         case NotificationTypes.GAME_REVIEW_COMPLETE:
-            return `${notification.gameReviewMetadata?.reviewer.displayName} reviewed your game. Check the game settings for more info.`;
+            return t('gameReviewCompleteDescription', {
+                reviewer: notification.gameReviewMetadata?.reviewer.displayName ?? '',
+            });
         case NotificationTypes.NEW_FOLLOWER:
             return `${notification.newFollowerMetadata?.displayName}`;
         case NotificationTypes.TIMELINE_COMMENT:
-            return `There ${count !== 1 ? `are ${count}` : 'is a'} new comment${
-                count !== 1 ? 's' : ''
-            } on your activity.`;
+            return t('timelineCommentDescription', { count });
         case NotificationTypes.TIMELINE_REACTION:
-            return `There ${count !== 1 ? `are ${count}` : 'is a'} new reaction${
-                count !== 1 ? 's' : ''
-            } on your activity.`;
+            return t('timelineReactionDescription', { count });
         case NotificationTypes.EXPLORER_GAME:
             if (notification.count === 1) {
-                return `A new game was added containing a position you follow.`;
+                return t('explorerGameDescription');
             }
             return '';
         case NotificationTypes.NEW_CLUB_JOIN_REQUEST:
-            return `There ${count !== 1 ? `are ${count}` : 'is a'} new request${
-                count !== 1 ? 's' : ''
-            } to join your club.`;
+            return t('clubJoinRequestDescription', { count });
         case NotificationTypes.CLUB_JOIN_REQUEST_APPROVED:
-            return 'Your request to join the club was approved.';
+            return t('clubJoinApprovedDescription');
         case NotificationTypes.CALENDAR_INVITE: {
             const start = new Date(notification.calendarInviteMetadata?.startTime || '');
-            return `${notification.calendarInviteMetadata?.ownerDisplayName} invited you to an event at ${toDojoDateString(start, undefined, undefined)} ${toDojoTimeString(start, undefined, undefined)}`;
+            return t('calendarInviteDescription', {
+                owner: notification.calendarInviteMetadata?.ownerDisplayName ?? '',
+                date: toDojoDateString(start, undefined, undefined),
+                time: toDojoTimeString(start, undefined, undefined),
+            });
         }
         case NotificationTypes.ROUND_ROBIN_START:
             return ``;

--- a/frontend/src/database/requirement.ts
+++ b/frontend/src/database/requirement.ts
@@ -350,16 +350,19 @@ export function getTotalTime(cohort: string, progress?: RequirementProgress): nu
  * @param value The number of minutes to display.
  * @returns The user-facing display string.
  */
-export function formatTime(value: number): string {
+export function formatTime(
+    value: number,
+    t: (key: string, values?: Record<string, string | number>) => string,
+): string {
     const hours = Math.floor(value / 60);
     const minutes = Math.round(value % 60);
     if (hours === 0) {
-        return `${minutes}m`;
+        return t('timeMinutes', { minutes });
     }
     if (minutes === 0) {
-        return `${hours}h`;
+        return t('timeHours', { hours });
     }
-    return `${hours}h ${minutes}m`;
+    return t('timeHoursMinutes', { hours, minutes });
 }
 
 /**

--- a/frontend/src/scoreboard/Scoreboard.tsx
+++ b/frontend/src/scoreboard/Scoreboard.tsx
@@ -411,14 +411,18 @@ function getTrainingPlanColumns(
  * @param allCohorts Whether all cohorts should be included for time spent.
  * @returns The columns for the Time Spent column group.
  */
-function getTimeSpentColumns(t: ScoreboardT, allCohorts?: boolean): GridColDef<ScoreboardRow>[] {
+function getTimeSpentColumns(
+    t: ScoreboardT,
+    tCommon: (key: string, values?: Record<string, string | number>) => string,
+    allCohorts?: boolean,
+): GridColDef<ScoreboardRow>[] {
     return [
         {
             field: 'totalTime',
             headerName: allCohorts ? t('allTasksColumn') : t('cohortTasksColumn'),
             valueGetter: (_value, row) =>
                 getMinutesSpent(row, allCohorts ? 'ALL_COHORTS_ALL_TIME' : 'ALL_TIME'),
-            valueFormatter: (value) => formatTime(value),
+            valueFormatter: (value) => formatTime(value, tCommon),
             align: 'center',
             minWidth: 125,
             headerAlign: 'center',
@@ -428,7 +432,7 @@ function getTimeSpentColumns(t: ScoreboardT, allCohorts?: boolean): GridColDef<S
             headerName: t('last7DaysColumn'),
             valueGetter: (_value, row) =>
                 getMinutesSpent(row, allCohorts ? 'ALL_COHORTS_LAST_7_DAYS' : 'LAST_7_DAYS'),
-            valueFormatter: (value) => formatTime(value),
+            valueFormatter: (value) => formatTime(value, tCommon),
             align: 'center',
             minWidth: 125,
             headerAlign: 'center',
@@ -438,7 +442,7 @@ function getTimeSpentColumns(t: ScoreboardT, allCohorts?: boolean): GridColDef<S
             headerName: t('last30DaysColumn'),
             valueGetter: (_value, row) =>
                 getMinutesSpent(row, allCohorts ? 'ALL_COHORTS_LAST_30_DAYS' : 'LAST_30_DAYS'),
-            valueFormatter: (value) => formatTime(value),
+            valueFormatter: (value) => formatTime(value, tCommon),
             align: 'center',
             minWidth: 125,
             headerAlign: 'center',
@@ -448,7 +452,7 @@ function getTimeSpentColumns(t: ScoreboardT, allCohorts?: boolean): GridColDef<S
             headerName: t('last90DaysColumn'),
             valueGetter: (_value, row) =>
                 getMinutesSpent(row, allCohorts ? 'ALL_COHORTS_LAST_90_DAYS' : 'LAST_90_DAYS'),
-            valueFormatter: (value) => formatTime(value),
+            valueFormatter: (value) => formatTime(value, tCommon),
             align: 'center',
             minWidth: 125,
             headerAlign: 'center',
@@ -458,7 +462,7 @@ function getTimeSpentColumns(t: ScoreboardT, allCohorts?: boolean): GridColDef<S
             headerName: t('last365DaysColumn'),
             valueGetter: (_value, row) =>
                 getMinutesSpent(row, allCohorts ? 'ALL_COHORTS_LAST_365_DAYS' : 'LAST_365_DAYS'),
-            valueFormatter: (value) => formatTime(value),
+            valueFormatter: (value) => formatTime(value, tCommon),
             align: 'center',
             minWidth: 125,
             headerAlign: 'center',
@@ -468,7 +472,7 @@ function getTimeSpentColumns(t: ScoreboardT, allCohorts?: boolean): GridColDef<S
             headerName: t('nonDojoColumn'),
             valueGetter: (_value, row) =>
                 getMinutesSpent(row, allCohorts ? 'ALL_COHORTS_NON_DOJO' : 'NON_DOJO'),
-            valueFormatter: (value) => formatTime(value),
+            valueFormatter: (value) => formatTime(value, tCommon),
             align: 'center',
             minWidth: 125,
             headerAlign: 'center',
@@ -498,6 +502,7 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
     slotProps,
 }) => {
     const t = useTranslations('scoreboard');
+    const tCommon = useTranslations('common');
     const isSummary = cohort === undefined;
     const isFreeTier = useFreeTier();
 
@@ -513,7 +518,10 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
         [t, cohort, requirements],
     );
 
-    const timeSpentColumns = useMemo(() => getTimeSpentColumns(t, isSummary), [t, isSummary]);
+    const timeSpentColumns = useMemo(
+        () => getTimeSpentColumns(t, tCommon, isSummary),
+        [t, tCommon, isSummary],
+    );
 
     const ratingsColumns = useMemo(() => getRatingsColumns(t), [t]);
     const summaryUserInfoColumns = useMemo(() => getSummaryUserInfoColumns(t), [t]);

--- a/frontend/src/scoreboard/ScoreboardProgress.tsx
+++ b/frontend/src/scoreboard/ScoreboardProgress.tsx
@@ -1,6 +1,7 @@
 import { TimelineProvider } from '@/components/profile/activity/useTimeline';
 import { TaskDialog, TaskDialogView } from '@/components/profile/trainingPlan/TaskDialog';
 import { Box, LinearProgress, LinearProgressProps, Typography } from '@mui/material';
+import { useTranslations } from 'next-intl';
 import { useState } from 'react';
 import { useAuth } from '../auth/Auth';
 import { Requirement, formatTime } from '../database/requirement';
@@ -22,12 +23,13 @@ export const ProgressText = ({
     suffix = '',
     isTime,
 }: ProgressTextProps) => {
+    const tCommon = useTranslations('common');
     let formattedLabel: string;
 
     if (label) {
         formattedLabel = label;
     } else if (isTime) {
-        formattedLabel = `${formatTime(value)} / ${formatTime(max)}`;
+        formattedLabel = `${formatTime(value, tCommon)} / ${formatTime(max, tCommon)}`;
     } else {
         formattedLabel = `${Math.max(value, min)} / ${max} ${suffix}`;
     }

--- a/frontend/src/stockfish/hooks/useChessDb.ts
+++ b/frontend/src/stockfish/hooks/useChessDb.ts
@@ -9,9 +9,11 @@ import { ChessDBService } from '@/api/chessdbService';
 import { useChess } from '@/board/pgn/PgnBoard';
 import { EventType } from '@jackstenglein/chess';
 import { validateFen } from 'chess.js';
+import { useTranslations } from 'next-intl';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; enablePv: boolean }) {
+    const t = useTranslations('analysisBoard.engine');
     const { chess } = useChess();
     const [data, setData] = useState<ChessDbMove[]>([]);
     const [loading, setLoading] = useState(false);
@@ -30,12 +32,12 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
                 setQueueing(true);
                 await chessDbService.queueAnalysis(fenString);
             } catch (err) {
-                setError(err instanceof Error ? err.message : 'Failed to queue analysis');
+                setError(err instanceof Error ? err.message : t('failedToQueueAnalysis'));
             } finally {
                 setQueueing(false);
             }
         },
-        [chessDbService],
+        [chessDbService, t],
     );
 
     const fetchPv = useCallback(
@@ -79,7 +81,7 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
                 return;
             }
             if (!validateFen(fenString)) {
-                setError('Invalid FEN provided');
+                setError(t('invalidFen'));
                 setData([]);
                 return;
             }
@@ -107,12 +109,12 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
                 }
             } catch (err) {
                 setData([]);
-                setError(err instanceof Error ? err.message : 'Failed to fetch data');
+                setError(err instanceof Error ? err.message : t('failedToFetchData'));
             } finally {
                 setLoading(false);
             }
         },
-        [queueAnalysis, chessDbService],
+        [queueAnalysis, chessDbService, t],
     );
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

~110 new translation keys across 50 files, finishing the customer-facing i18n extraction. Picks up what was missed or deferred from earlier PRs: files with no next-intl usage yet, enum display functions, residual aria-labels and tooltips in already-extracted files, module-level constants that needed factory function conversion, and the formatTime "Xh Ym" abbreviations. en.json grows from 3254 to 3377.

### What's covered

- **puzzles.hintSection** (14 keys) - turn prompts, move hints, completion messages, button labels
- **calendar** (22 keys) - event title fallbacks (Meeting, Bookable, Available), validation error messages, filter buttons. processAvailability and getProcessedEvents take t as a parameter; CoachingCalendar updated to pass tCalendar.
- **timer** (4 keys) - pause/resume/start/clear labels in TimerContext
- **notifications** (14 keys) - notification titles and descriptions. getTitle and getDescription in notification.ts take t as parameter. 4 ICU plurals for comment replies, timeline comments/reactions, club join requests.
- **liveClasses** (14 keys) - new top-level namespace for LiveClassesPage marketing copy, subscription buttons, recordings link via t.rich
- **analysisBoard.engine** (16 keys) - engine descriptions and tech descriptions translated at the render callsite with dynamic keys, eval type labels, ChessDB error strings in useChessDb hook
- **errors** (5 keys) - ErrorBoundary error display extracted to a functional ErrorDisplay component so it can call useTranslations. Not-found pages.
- **dojoDigest** (4 keys) - unsubscribe page
- **exams** (3 keys) - displayExamType takes t as parameter, caller in ExamInstructionsPage updated
- **games** (2 keys) - displayGameReviewType renamed shadow param from t to reviewType, takes t as second parameter. All 4 callers in RequestReviewDialog and AdminSettings updated.
- **common** (3 keys) - formatTime abbreviations ({hours}h, {minutes}m, {hours}h {minutes}m). All 21 callsites across heatmap, scoreboard, newsfeed, training plan, and year review updated.
- **tournaments.openClassical.pairings** (5 keys) - column headers and unverified result tooltip. pairingTableColumns converted to getPairingTableColumns factory function. Admin PairingsTab updated.
- **tournaments.roundRobin** (3 keys) - aria-labels on stat toggles and tab bar
- **profile.trainingPlan** (7 keys) - graduation task name/description in FullTrainingPlan (getGraduationFakeTask takes t), checkbox/update aria-labels, active-only filter tooltip and label
- **profile.activity** (1 key) - rest day cleared snackbar
- **profile.directories** (0 new keys) - publicColumns and adminColumns converted to getPublicColumns/getAdminColumns factory functions using existing keys from prior PR
- **analysisBoard.underboard** (4 keys) - comment timestamp tooltip, game-added-to-folder success, merge line error, field required validation
- **games.downloadDialog** (1 key) - request timeout error
- **learn.guides** (1 key) - iframe title (was copy/pasted "Dojo Guide To Bots" on all 4 iframes)
- **scoreboard, newsfeed** (0 new keys) - threaded tCommon through formatTime callsites in Scoreboard column valueFormatters, ScoreboardProgress, NewsfeedItem, GraduationNewsfeedItem
- **calendar.eventValidation** (12 keys) - validateEventEditor takes t, threaded through all 11 internal validation functions. Shadow rename t -> at in availabilityTypes filter callback.

### Patterns

- t-as-parameter for module-level helpers that can't call hooks: formatTime (requirement.ts), displayExamType, displayGameReviewType, getTitle/getDescription (notification.ts), validateEventEditor (threaded through 11 internal functions), getProcessedEvents/processAvailability (CalendarPage), taskTitle (DailyTrainingPlan), getGraduationFakeTask (FullTrainingPlan)
- Module-level constants converted to factory functions with useMemo([t]): getPairingTableColumns, getPublicColumns/getAdminColumns (DirectoryGridColumns), getPrimaryAxis/getBarAxis (ClockUsage), getTimeSecondaryAxes (StatisticsPage, TimeSection). Scoreboard's getTimeSpentColumns gains a tCommon parameter.
- Engine descriptions translated at the render callsite with dynamic keys rather than modifying the engines array. Each engine's name enum value is the key suffix.
- ErrorBoundary is a class component so the error display was extracted to a functional ErrorDisplay component, similar to the PgnErrorBoundary pattern from the prior PR.
- ICU plural conversions where the original had manual English ternaries (byte-identical output): gameCommentReplyDescription, timelineCommentDescription, timelineReactionDescription, clubJoinRequestDescription
- Shadow renames: t -> ct (TimerContext find callback), t -> at (eventValidation filter callback), t -> reviewType (displayGameReviewType parameter)
- t.rich for LiveClassesPage recordings link with embedded Link component

### Also fixed

- ProgressHistory delete button had a bare aria-label='delete' that was missed in prior extraction passes
- WeeklyTrainingPlan "Active Only" label and tooltip were hardcoded
- FullTrainingPlan graduation task name/description used template literals at module level
- Comment.tsx timestamp tooltip was a template literal
- guides/page.tsx iframe titles were all copy/pasted "Dojo Guide To Bots" regardless of section

## Related issues

Part of #1997

## Dependencies

Depends on #2199 - merge that first.

## Type of change

- [x] New feature

## Testing

- [x] Not necessary (string extraction only, no logic changes)
- Locally verified: prettier, tsc, eslint, unit tests (182 pass), JSON parity (en 3377 / pseudo 3377, diff 0)

## Demo

Screenshot/recording to be added