### PR TITLE
fix(#1997): stop serializing en.json into every page's RSC payload

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import { MetaPixel } from '@/components/analytics/MetaPixel';
 import { WebVitals } from '@/components/analytics/WebVitals';
 import { I18nProvider } from '@/i18n/I18nProvider';
-import { getLocale, getMessages } from 'next-intl/server';
+import { getLocale } from 'next-intl/server';
 import { NavigationGuardProvider } from 'next-navigation-guard';
 import { defaultMetadata } from './(scoreboard)/defaultMetadata';
 
@@ -9,7 +9,6 @@ export const metadata = defaultMetadata;
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
     const locale = await getLocale();
-    const messages = await getMessages();
 
     return (
         <html lang={locale} suppressHydrationWarning className='dark'>
@@ -18,7 +17,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
                 <link rel='manifest' href='/manifest.json' />
             </head>
             <body>
-                <I18nProvider defaultLocale={locale} defaultMessages={messages}>
+                <I18nProvider>
                     <NavigationGuardProvider>
                         <MetaPixel />
                         <WebVitals />

--- a/frontend/src/i18n/I18nProvider.tsx
+++ b/frontend/src/i18n/I18nProvider.tsx
@@ -4,6 +4,7 @@ import { DEFAULT_LOCALE, LOCALE_CODES } from '@/i18n/locales';
 import { logger } from '@/logging/logger';
 import { AbstractIntlMessages, NextIntlClientProvider } from 'next-intl';
 import { useEffect, useState } from 'react';
+import enMessages from '../../messages/en.json';
 
 function getLocaleCookie(): string {
     if (typeof document === 'undefined') return DEFAULT_LOCALE;
@@ -12,17 +13,11 @@ function getLocaleCookie(): string {
     return LOCALE_CODES.includes(value) ? value : DEFAULT_LOCALE;
 }
 
-export function I18nProvider({
-    defaultLocale,
-    defaultMessages,
-    children,
-}: {
-    defaultLocale: string;
-    defaultMessages: AbstractIntlMessages;
-    children: React.ReactNode;
-}) {
-    const [locale, setLocale] = useState(defaultLocale);
-    const [messages, setMessages] = useState(defaultMessages);
+export function I18nProvider({ children }: { children: React.ReactNode }) {
+    const [locale, setLocale] = useState<string>(DEFAULT_LOCALE);
+    const [messages, setMessages] = useState<AbstractIntlMessages>(
+        enMessages as AbstractIntlMessages,
+    );
 
     useEffect(() => {
         const cookieLocale = getLocaleCookie();


### PR DESCRIPTION
## Summary

Root layout passed 263 KB of `en.json` to `I18nProvider` (a client component),
so next serialized the messages into every prerendered page's RSC file and the
build output hit Amplify's 220 MB compute limit.

Fix: static-import `en.json` inside `I18nProvider`, drop the props from the
layout. Server components still translate via `i18n/request.ts` and client
locale switching is unchanged.

## Related issues

Part of #1997

## Type of change

- [x] Bug fix

## Testing

- [x] Not necessary (infrastructure fix, no UI change)
- Locally verified: prettier, tsc (clean), eslint, unit tests (182/182), clean
  `build:beta` on both `upstream/intl` and this branch

## Demo

N/A (no user-visible change)