### PR TITLE
feat(1997): drop /en/ prefix from default-locale URLs

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -56,11 +56,22 @@ const nextConfig = {
         return headers;
     },
     redirects: () => [
+        // SEO: permanent redirect for default-locale prefix removal under
+        // localePrefix: 'as-needed'. next-intl's middleware emits a 307
+        // (temporary) for /en/foo -> /foo, which search engines do not
+        // honour for canonicalization. A Next-level 308 transfers authority
+        // and also cuts one middleware invocation per /en/... request.
+        { source: '/en', destination: '/', permanent: true },
+        { source: '/en/:path*', destination: '/:path*', permanent: true },
+
+        // Each legacy redirect needs a bare AND a prefixed variant.
+        { source: '/games/explorer', destination: '/games/analysis', permanent: true },
         {
             source: `/${LOCALE_PATTERN}/games/explorer`,
             destination: '/:locale/games/analysis',
             permanent: true,
         },
+        { source: '/material/bots', destination: '/learn/guides', permanent: true },
         {
             source: `/${LOCALE_PATTERN}/material/bots`,
             destination: '/:locale/learn/guides',
@@ -147,8 +158,14 @@ const pagesWithVideosRaw = [
     '/courses/OPENING/179bf457-05fa-4405-9b61-4c12b6687932/0/2',
 ];
 
-const pagesWithVideos = pagesWithVideosRaw.map((p) =>
-    p === '/' ? `/${LOCALE_PATTERN}` : `/${LOCALE_PATTERN}${p}`,
-);
+// Under localePrefix: 'as-needed', default-locale URLs are bare ('/profile',
+// '/blog/...'). Emit BOTH bare and prefixed variants so COEP overrides land
+// for English visitors as well — otherwise bare URLs fall through to the
+// catch-all '/:path*' ENGINE_HEADERS rule (require-corp), breaking video
+// embeds and the stockfish engine.
+const pagesWithVideos = pagesWithVideosRaw.flatMap((p) => {
+    const prefixed = p === '/' ? `/${LOCALE_PATTERN}` : `/${LOCALE_PATTERN}${p}`;
+    return [p, prefixed];
+});
 
 export default withNextIntl(nextConfig);

--- a/frontend/playwright/tests/e2e/games/list/list.spec.ts
+++ b/frontend/playwright/tests/e2e/games/list/list.spec.ts
@@ -53,7 +53,7 @@ test.describe('List Games Page', () => {
 
         await waitForNavigation(
             page,
-            /\/(en|pseudo|de)\/games\?type=player&player=JackStenglein&color=either&startDate=&endDate=$/,
+            /\/(?:(?:en|pseudo|de)\/)?games\?type=player&player=JackStenglein&color=either&startDate=&endDate=$/,
         );
     });
 
@@ -69,7 +69,7 @@ test.describe('List Games Page', () => {
 
         await waitForNavigation(
             page,
-            /\/(en|pseudo|de)\/games\?type=opening&eco=B01&startDate=&endDate=$/,
+            /\/(?:(?:en|pseudo|de)\/)?games\?type=opening&eco=B01&startDate=&endDate=$/,
         );
     });
 
@@ -81,7 +81,10 @@ test.describe('List Games Page', () => {
         await expect(searchForm.getByTestId('owner-search-button')).toBeVisible();
         await searchForm.getByTestId('owner-search-button').click();
 
-        await waitForNavigation(page, /\/(en|pseudo|de)\/games\?type=owner&startDate=&endDate=$/);
+        await waitForNavigation(
+            page,
+            /\/(?:(?:en|pseudo|de)\/)?games\?type=owner&startDate=&endDate=$/,
+        );
     });
 
     test('links to game page on row click', async ({ page }) => {

--- a/frontend/playwright/tests/e2e/i18n/db-overlay.spec.ts
+++ b/frontend/playwright/tests/e2e/i18n/db-overlay.spec.ts
@@ -1,12 +1,18 @@
 import { expect, test } from '@playwright/test';
 
 test.describe('DB overlay - course titles per locale', () => {
-    test('english /courses course titles are plain (no [T] prefix)', async ({ page }) => {
-        await page.goto('/en/courses');
+    test('english bare /courses course titles are plain (no [T] prefix)', async ({ page }) => {
+        await page.goto('/courses');
 
         const firstTitle = page.getByRole('heading', { level: 5 }).first();
         await expect(firstTitle).toBeVisible({ timeout: 15000 });
         await expect(firstTitle).not.toHaveText(/^\[T\]/);
+    });
+
+    test('/en/courses permanently redirects to bare /courses', async ({ page }) => {
+        await page.goto('/en/courses');
+        // next.config.mjs 308s /en/* -> /* for SEO authority transfer.
+        await expect(page).toHaveURL(/\/courses$/);
     });
 
     test('pseudo /courses course titles show [T] prefix', async ({ page }) => {

--- a/frontend/playwright/tests/e2e/i18n/routing.spec.ts
+++ b/frontend/playwright/tests/e2e/i18n/routing.spec.ts
@@ -1,40 +1,54 @@
 import { expect, test } from '@playwright/test';
 
-test.describe('URL-prefixed locales - unauthenticated', () => {
+test.describe('localePrefix: as-needed - unauthenticated', () => {
     // Run these routing tests without auth so bare-URL redirects are not
     // confounded by the authenticated-user redirect to /profile.
     test.use({ storageState: { cookies: [], origins: [] } });
 
-    test('bare / redirects to a locale-prefixed root', async ({ page }) => {
+    test('bare / stays bare for en-US Accept-Language (no cookie)', async ({ browser }) => {
+        const context = await browser.newContext({
+            locale: 'en-US',
+            storageState: { cookies: [], origins: [] },
+        });
+        const page = await context.newPage();
         await page.goto('/');
-        // Chrome's default Accept-Language is en-US, so middleware should
-        // redirect to /en. Accept /pseudo as a fallback in case the server
-        // is running in pseudo-locale mode.
-        await expect(page).toHaveURL(/\/(en|pseudo|de)\/?$/);
+        await expect(page).toHaveURL(/\/$/);
+        await context.close();
     });
 
-    test('bare /profile redirects to /en/profile (unauthenticated user sees landing)', async ({
-        page,
+    test('bare / redirects to /de for de-DE Accept-Language (no cookie)', async ({ browser }) => {
+        const context = await browser.newContext({
+            locale: 'de-DE',
+            storageState: { cookies: [], origins: [] },
+        });
+        const page = await context.newPage();
+        await page.goto('/');
+        await expect(page).toHaveURL(/\/de\/?$/);
+        await context.close();
+    });
+
+    test('bare /profile redirects to bare landing for en-US (unauthenticated)', async ({
+        browser,
     }) => {
+        const context = await browser.newContext({
+            locale: 'en-US',
+            storageState: { cookies: [], origins: [] },
+        });
+        const page = await context.newPage();
         await page.goto('/profile');
-        // Middleware redirects /profile -> /en/profile; the page itself may
-        // then redirect an unauthenticated user back to the root with a
-        // redirectUri param. Either way the locale prefix /en must appear.
-        await expect(page).toHaveURL(/\/(en|pseudo|de)([/?#]|$)/);
+        await expect(page).toHaveURL(/\/\?redirectUri=/);
+        await context.close();
     });
 
     test('pseudo locale route renders on nonprod', async ({ page }) => {
         await page.goto('/pseudo');
-        // The route should not redirect away from /pseudo.
         await expect(page).toHaveURL(/\/pseudo\/?$/);
-        // The pseudo locale prepends "[T] " to translated strings, so the
-        // page body should contain that prefix somewhere.
+        // The pseudo locale prepends "[T] " to translated strings.
         await expect(page.locator('body')).toContainText('[T]', { timeout: 15000 });
     });
 
     test('cookie-set locale is honoured on bare URL visit', async ({ page, context }) => {
-        // Simulate a user who previously selected the pseudo locale by
-        // injecting the locale cookie that the picker writes.
+        // Simulate a user who previously selected the pseudo locale.
         await context.addCookies([
             {
                 name: 'locale',
@@ -44,27 +58,36 @@ test.describe('URL-prefixed locales - unauthenticated', () => {
             },
         ]);
         await page.goto('/profile');
-        // Middleware reads the cookie and prefixes with /pseudo instead of /en.
+        // Cookie wins over Accept-Language; bare URL gets prefixed to /pseudo.
         await expect(page).toHaveURL(/\/pseudo([/?#]|$)/);
+    });
+
+    test('/en/profile permanently redirects to /profile', async ({ page }) => {
+        const response = await page.goto('/en/profile');
+        // Playwright follows redirects, so only the final URL is visible.
+        await expect(page).toHaveURL(/\/profile/);
+        expect(response?.url()).not.toMatch(/\/en\/profile/);
     });
 });
 
-test.describe('URL-prefixed locales - authenticated', () => {
+test.describe('localePrefix: as-needed - authenticated', () => {
     // Uses the default storageState from playwright.config.ts (authenticated).
 
-    test('/en/profile passes through without redirect loop', async ({ page }) => {
-        await page.goto('/en/profile');
-        // An authenticated user visiting /en/profile should stay at
-        // /en/profile (or /en/profile?... if the profile page adds params),
-        // NOT get bounced back to /?redirectUri=... since they are logged in.
-        await expect(page).toHaveURL(/\/en\/profile/);
+    test('bare /profile renders the authenticated profile page', async ({ page }) => {
+        const response = await page.goto('/profile');
+        // No locale prefix on default-locale URLs; authenticated user stays put.
+        // Assert 200 explicitly — a broken x-middleware-rewrite forward in
+        // proxy.ts would leave the URL bare but 404 the page, which a URL-
+        // only assertion misses.
+        expect(response?.status()).toBe(200);
+        await expect(page).toHaveURL(/\/profile/);
+        await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
     });
 
     test('unknown route under a valid locale returns 404', async ({ page }) => {
-        // /fr/profile gets prefixed by next-intl to /en/fr/profile (fr is not
-        // in SUPPORTED_LOCALES), which Next.js renders via [locale]/not-found.
-        // An unauthenticated user would instead get bounced to the landing
-        // with a redirectUri by the proxy, so this test must run authenticated.
+        // /fr/profile is not a registered locale; next-intl renders the
+        // [locale]/not-found page. An unauthenticated user would be bounced
+        // by the proxy, so this test must run authenticated.
         const response = await page.goto('/fr/profile');
         expect(response?.status()).toBe(404);
     });

--- a/frontend/playwright/tests/e2e/i18n/routing.spec.ts
+++ b/frontend/playwright/tests/e2e/i18n/routing.spec.ts
@@ -63,10 +63,11 @@ test.describe('localePrefix: as-needed - unauthenticated', () => {
     });
 
     test('/en/profile permanently redirects to /profile', async ({ page }) => {
-        const response = await page.goto('/en/profile');
-        // Playwright follows redirects, so only the final URL is visible.
-        await expect(page).toHaveURL(/\/profile/);
-        expect(response?.url()).not.toMatch(/\/en\/profile/);
+        const response = await page.context().request.get('/en/profile', {
+            maxRedirects: 0,
+        });
+        expect(response.status()).toBe(308);
+        expect(response.headers().location).toBe('/profile');
     });
 });
 
@@ -75,13 +76,8 @@ test.describe('localePrefix: as-needed - authenticated', () => {
 
     test('bare /profile renders the authenticated profile page', async ({ page }) => {
         const response = await page.goto('/profile');
-        // No locale prefix on default-locale URLs; authenticated user stays put.
-        // Assert 200 explicitly — a broken x-middleware-rewrite forward in
-        // proxy.ts would leave the URL bare but 404 the page, which a URL-
-        // only assertion misses.
         expect(response?.status()).toBe(200);
         await expect(page).toHaveURL(/\/profile/);
-        await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
     });
 
     test('unknown route under a valid locale returns 404', async ({ page }) => {

--- a/frontend/playwright/tests/e2e/landing/landing.spec.ts
+++ b/frontend/playwright/tests/e2e/landing/landing.spec.ts
@@ -24,13 +24,16 @@ test.describe('Landing Page (unauthenticated)', () => {
 
     test('has explore button', async ({ page }) => {
         await page.getByRole('button', { name: 'Explore the Program' }).click();
-        await expect(page).toHaveURL(/^http:\/\/localhost:3000\/(en|pseudo|de)\/?$/);
+        await expect(page).toHaveURL(
+            /^http:\/\/localhost:3000\/(en|pseudo|de)?\/?$|^http:\/\/localhost:3000\/$/,
+        );
     });
 
     test('should redirect unauthenticated user to landing', async ({ page }) => {
         await page.goto('/profile');
-        // URL may include redirectUri query param to remember intended destination
-        await expect(page).toHaveURL(/^http:\/\/localhost:3000\/(en|pseudo|de)\/?\??(.*)$/);
+        await expect(page).toHaveURL(
+            /^http:\/\/localhost:3000\/(pseudo|de)?\/?\??(.*)$|^http:\/\/localhost:3000\/\??(.*)$/,
+        );
     });
 });
 

--- a/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
@@ -253,7 +253,10 @@ export function ProfileEditorPage({ user }: { user: User }) {
                     // navigation leaves some client components holding on to
                     // the previous locale's messages (the language changes
                     // only after a second switch), so force a full fetch.
-                    window.location.href = `/${update.language}/profile`;
+                    window.location.href =
+                        update.language === DEFAULT_LOCALE
+                            ? '/profile'
+                            : `/${update.language}/profile`;
                 } else {
                     router.push('/profile');
                 }

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -34,11 +34,15 @@ export async function generateMetadata({
     const { locale } = await params;
     const base = config.baseUrl.replace(/\/$/, '');
 
+    // Under localePrefix: 'as-needed' the default locale lives at the bare
+    // domain root; non-default locales keep their prefix. x-default and the
+    // default-locale entry must both point at `base` to match the URL Google
+    // actually crawls.
     const languages: Record<string, string> = {};
     for (const code of PUBLIC_LOCALES) {
-        languages[code] = `${base}/${code}`;
+        languages[code] = code === DEFAULT_LOCALE ? base : `${base}/${code}`;
     }
-    languages['x-default'] = `${base}/${DEFAULT_LOCALE}`;
+    languages['x-default'] = base;
 
     return {
         ...defaultMetadata,
@@ -47,7 +51,7 @@ export async function generateMetadata({
         },
         openGraph: {
             ...(defaultMetadata.openGraph ?? {}),
-            url: `${base}/${locale}`,
+            url: locale === DEFAULT_LOCALE ? base : `${base}/${locale}`,
         },
     };
 }

--- a/frontend/src/components/auth/RequireProfile.tsx
+++ b/frontend/src/components/auth/RequireProfile.tsx
@@ -4,7 +4,7 @@ import { useApi } from '@/api/Api';
 import { useRequest } from '@/api/Request';
 import { AuthStatus, useAuth } from '@/auth/Auth';
 import { hasCreatedProfile } from '@/database/user';
-import { LOCALE_CODES, setLocaleCookie } from '@/i18n/locales';
+import { DEFAULT_LOCALE, LOCALE_CODES, setLocaleCookie } from '@/i18n/locales';
 import { usePathname, useRouter } from '@/i18n/navigation';
 import { AxiosError } from 'axios';
 import { useLocale } from 'next-intl';
@@ -53,7 +53,15 @@ export function RequireProfile() {
             preferred !== currentLocale &&
             (LOCALE_CODES as readonly string[]).includes(preferred)
         ) {
-            router.replace(pathname, { locale: preferred });
+            // next-intl 4.x: passing { locale } always emits a prefixed URL
+            // even under as-needed (to let the cookie write before hydration).
+            // For the default locale we drop the option and rely on the cookie
+            // set above, so the URL lands at the bare path instead of /en/...
+            if (preferred === DEFAULT_LOCALE) {
+                router.replace(pathname);
+            } else {
+                router.replace(pathname, { locale: preferred });
+            }
         }
     }, [user?.language, currentLocale, router, pathname]);
 

--- a/frontend/src/components/navigation/Link.tsx
+++ b/frontend/src/components/navigation/Link.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { pagesWithVideos } from '@/hooks/useRouter';
-import { LOCALE_CODES } from '@/i18n/locales';
+import { DEFAULT_LOCALE, LOCALE_CODES } from '@/i18n/locales';
 import { Link as NextLink, usePathname } from '@/i18n/navigation';
 import { LinkProps, Link as MuiLink } from '@mui/material';
 import { useLocale } from 'next-intl';
@@ -84,9 +84,13 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
                     }
 
                     guard.enabled = () => false;
-                    // Absolute URLs pass through; relative ones get the active locale prefix.
+                    // Absolute URLs pass through. Relative URLs get the active
+                    // locale prefix — except under localePrefix: 'as-needed',
+                    // the default locale uses bare paths.
                     if (hrefIsExternal || !hrefStripped) {
                         window.location.href = rawHref;
+                    } else if (locale === DEFAULT_LOCALE) {
+                        window.location.href = hrefStripped;
                     } else {
                         window.location.href = `/${locale}${hrefStripped}`;
                     }

--- a/frontend/src/hooks/useRouter.ts
+++ b/frontend/src/hooks/useRouter.ts
@@ -1,4 +1,4 @@
-import { LOCALE_CODES } from '@/i18n/locales';
+import { DEFAULT_LOCALE, LOCALE_CODES } from '@/i18n/locales';
 import { useRouter as useNextRouter, usePathname } from '@/i18n/navigation';
 import { useLocale } from 'next-intl';
 
@@ -8,6 +8,10 @@ function isAbsoluteUrl(href: string): boolean {
     return /^[a-z]+:/i.test(href) || href.startsWith('//');
 }
 
+// Regexes match the locale-stripped pathname returned by next-intl's
+// usePathname(). Do NOT prefix with /${locale} — next.config.mjs handles
+// COEP-header source matching separately via its own flatMap that emits
+// both bare and prefixed variants.
 export const pagesWithVideos = [
     /^\/$/,
     /\/profile.*/,
@@ -78,6 +82,8 @@ export function useRouter() {
 
         if (currentHasVideo === newHasVideo) {
             router.push(normalized, options);
+        } else if (targetLocale === DEFAULT_LOCALE) {
+            window.location.href = normalized;
         } else {
             window.location.href = `/${targetLocale}${normalized}`;
         }

--- a/frontend/src/i18n/routing.test.ts
+++ b/frontend/src/i18n/routing.test.ts
@@ -18,8 +18,8 @@ describe('routing config', () => {
         expect(routing.defaultLocale).toBe('en');
     });
 
-    it('uses always prefix mode', () => {
-        expect(routing.localePrefix).toBe('always');
+    it('uses as-needed prefix mode', () => {
+        expect(routing.localePrefix).toBe('as-needed');
     });
 
     it('enables locale detection', () => {

--- a/frontend/src/i18n/routing.ts
+++ b/frontend/src/i18n/routing.ts
@@ -4,11 +4,12 @@ import { DEFAULT_LOCALE, LOCALE_CODES } from './locales';
 export const routing = defineRouting({
     locales: LOCALE_CODES,
     defaultLocale: DEFAULT_LOCALE,
-    localePrefix: 'always',
+    localePrefix: 'as-needed',
     localeDetection: true,
     localeCookie: {
         name: 'locale',
         maxAge: 60 * 60 * 24 * 365,
         sameSite: 'lax',
+        secure: process.env.NODE_ENV === 'production',
     },
 });

--- a/frontend/src/i18n/sanitizeRedirectUri.test.ts
+++ b/frontend/src/i18n/sanitizeRedirectUri.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeRedirectUri } from './sanitizeRedirectUri';
+
+describe('sanitizeRedirectUri', () => {
+    it('returns fallback for null, undefined, empty string', () => {
+        expect(sanitizeRedirectUri(null)).toBe('/profile');
+        expect(sanitizeRedirectUri(undefined)).toBe('/profile');
+        expect(sanitizeRedirectUri('')).toBe('/profile');
+    });
+
+    it('honours a custom fallback', () => {
+        expect(sanitizeRedirectUri(null, '/')).toBe('/');
+    });
+
+    it('passes through a bare same-origin path', () => {
+        expect(sanitizeRedirectUri('/profile/edit')).toBe('/profile/edit');
+    });
+
+    it('preserves query string and fragment', () => {
+        expect(sanitizeRedirectUri('/games/import?source=lichess')).toBe(
+            '/games/import?source=lichess',
+        );
+        expect(sanitizeRedirectUri('/profile/edit#notifications-email')).toBe(
+            '/profile/edit#notifications-email',
+        );
+    });
+
+    it('decodes percent-encoded input', () => {
+        expect(sanitizeRedirectUri('%2Fprofile%2Fedit')).toBe('/profile/edit');
+    });
+
+    it('strips a stale locale prefix', () => {
+        expect(sanitizeRedirectUri('/en/profile')).toBe('/profile');
+        expect(sanitizeRedirectUri('/de/profile')).toBe('/profile');
+        expect(sanitizeRedirectUri('/pseudo/profile')).toBe('/profile');
+    });
+
+    it('collapses to / when only a locale prefix is present', () => {
+        expect(sanitizeRedirectUri('/en')).toBe('/');
+        expect(sanitizeRedirectUri('/de')).toBe('/');
+    });
+
+    it('rejects absolute http(s) URLs', () => {
+        expect(sanitizeRedirectUri('http://evil.com')).toBe('/profile');
+        expect(sanitizeRedirectUri('https://evil.com/path')).toBe('/profile');
+    });
+
+    it('rejects protocol-relative URLs', () => {
+        expect(sanitizeRedirectUri('//evil.com')).toBe('/profile');
+        expect(sanitizeRedirectUri('//evil.com/path')).toBe('/profile');
+    });
+
+    it('rejects backslash-prefixed bypass attempts', () => {
+        expect(sanitizeRedirectUri('/\\evil.com')).toBe('/profile');
+        expect(sanitizeRedirectUri('\\evil.com')).toBe('/profile');
+        expect(sanitizeRedirectUri('\\\\evil.com')).toBe('/profile');
+    });
+
+    it('rejects paths that do not start with /', () => {
+        expect(sanitizeRedirectUri('profile')).toBe('/profile');
+        expect(sanitizeRedirectUri('javascript:alert(1)')).toBe('/profile');
+    });
+
+    it('returns fallback for malformed percent encoding', () => {
+        expect(sanitizeRedirectUri('%E0%A4%A')).toBe('/profile');
+    });
+});

--- a/frontend/src/i18n/sanitizeRedirectUri.ts
+++ b/frontend/src/i18n/sanitizeRedirectUri.ts
@@ -4,9 +4,11 @@ const LOCALE_PREFIX_REGEX = new RegExp(`^/(${LOCALE_CODES.join('|')})(?=/|$)`);
 
 // Normalize a ?redirectUri= query param before handing it to next-intl's
 // auto-prefixing router. Strips any stale locale prefix so
-// router.push('/en/profile') doesn't end up at /en/en/profile, and
-// rejects external URLs so a crafted redirectUri=https://evil.com can't
-// bounce the user off-site after signin.
+// router.push('/en/profile') doesn't end up at /en/en/profile, and rejects
+// anything that isn't a same-origin absolute path. Allow-list rather than
+// deny-list: '/\\evil.com' and '\\evil.com' are protocol-relative in
+// browsers that normalize backslashes, so a deny-list against 'http' and
+// '//' alone would let those through.
 export function sanitizeRedirectUri(raw: string | null | undefined, fallback = '/profile'): string {
     if (!raw) return fallback;
     let decoded: string;
@@ -15,7 +17,7 @@ export function sanitizeRedirectUri(raw: string | null | undefined, fallback = '
     } catch {
         return fallback;
     }
-    if (decoded.startsWith('http') || decoded.startsWith('//')) {
+    if (!decoded.startsWith('/') || decoded.startsWith('//') || decoded.startsWith('/\\')) {
         return fallback;
     }
     return decoded.replace(LOCALE_PREFIX_REGEX, '') || '/';

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -16,9 +16,14 @@ if (LOCALE_CODES.length === 0) {
 }
 const LOCALE_PREFIX_REGEX = new RegExp(`^/(${LOCALE_CODES.join('|')})(?=/|$)`);
 
-function withPrefix(prefix: string, path: string): string {
+// Under localePrefix: 'as-needed', the default locale is served at bare URLs
+// (e.g. '/profile' for en). Non-default locales keep their prefix
+// ('/pseudo/profile', '/de/profile'). Without this carve-out we'd emit '/en/...'
+// and rely on next-intl to redirect it back to bare — one extra round-trip per
+// auth gate or legacy-route redirect.
+function buildPath(locale: string, path: string): string {
     if (path.startsWith('http')) return path;
-    return `${prefix}${path}`;
+    return locale === DEFAULT_LOCALE ? path : `/${locale}${path}`;
 }
 
 const publicPaths = [
@@ -78,9 +83,11 @@ const legacyRoutes = [
 ];
 
 export async function proxy(request: NextRequest) {
-    // Run next-intl first so bare URLs get redirected to /<locale>/<path>
-    // before auth/legacy matchers see them. Try/catch keeps a library throw
-    // from 500'ing every page.
+    // Run next-intl first. For non-default locales it returns a redirect
+    // (Location header); for the default locale under as-needed it returns
+    // a rewrite (x-middleware-rewrite) with no Location. If it's a redirect,
+    // short-circuit now. Otherwise fall through and forward its rewrite +
+    // cookie headers onto whatever the auth/legacy logic decides to return.
     let intlResponse: NextResponse | undefined;
     try {
         intlResponse = intlMiddleware(request);
@@ -91,23 +98,53 @@ export async function proxy(request: NextRequest) {
         return intlResponse;
     }
 
+    // Under as-needed, next-intl rewrites bare default-locale URLs internally
+    // via x-middleware-rewrite (no Location header) and sets a Set-Cookie on
+    // first visits. We must forward both onto our own response or Next will
+    // 404 the bare URL (no [locale] segment match) and the locale cookie will
+    // be lost forever. getSetCookie() returns each cookie separately; fall
+    // back to get('set-cookie') for runtimes that don't expose it.
+    function forwardIntlHeaders(target: NextResponse): NextResponse {
+        if (!intlResponse) return target;
+        const headers = intlResponse.headers;
+        const rewrite = headers.get('x-middleware-rewrite');
+        // x-middleware-rewrite is meaningless on a redirect response and Next
+        // currently ignores it there, but a future version honouring it would
+        // double-rewrite. Gate to pass-through responses only.
+        if (rewrite && !target.headers.get('location')) {
+            target.headers.set('x-middleware-rewrite', rewrite);
+        }
+
+        const cookies = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : [];
+        if (cookies.length > 0) {
+            for (const cookie of cookies) {
+                target.headers.append('set-cookie', cookie);
+            }
+        } else {
+            const single = headers.get('set-cookie');
+            if (single) target.headers.append('set-cookie', single);
+        }
+        return target;
+    }
+
     // Strip the locale prefix so the matchers below stay locale-agnostic.
     const localeMatch = LOCALE_PREFIX_REGEX.exec(request.nextUrl.pathname);
     const locale = localeMatch?.[1] ?? DEFAULT_LOCALE;
-    const prefix = `/${locale}`;
     const pathname = request.nextUrl.pathname.replace(LOCALE_PREFIX_REGEX, '') || '/';
 
     const response = NextResponse.next();
 
     for (const path of publicPaths) {
         if (pathname.match(path)) {
-            return response;
+            return forwardIntlHeaders(response);
         }
     }
 
     for (const route of legacyRoutes) {
         if (pathname === route.oldPath) {
-            return NextResponse.redirect(new URL(withPrefix(prefix, route.newPath), request.url));
+            return forwardIntlHeaders(
+                NextResponse.redirect(new URL(buildPath(locale, route.newPath), request.url)),
+            );
         }
     }
 
@@ -130,7 +167,9 @@ export async function proxy(request: NextRequest) {
     if (authenticated) {
         for (const [path, redirect] of authenticatedRedirects) {
             if (pathname.match(path)) {
-                return NextResponse.redirect(new URL(withPrefix(prefix, redirect), request.url));
+                return forwardIntlHeaders(
+                    NextResponse.redirect(new URL(buildPath(locale, redirect), request.url)),
+                );
             }
         }
     }
@@ -143,15 +182,30 @@ export async function proxy(request: NextRequest) {
     }
 
     if (authenticated !== unauthenticatedPath) {
-        return response;
+        return forwardIntlHeaders(response);
     }
 
     if (authenticated) {
-        return NextResponse.redirect(new URL(`${prefix}/profile`, request.url));
+        return forwardIntlHeaders(
+            NextResponse.redirect(new URL(buildPath(locale, '/profile'), request.url)),
+        );
     }
 
-    // Pass the unprefixed pathname so signin's router doesn't double-prefix.
-    return NextResponse.redirect(new URL(`${prefix}/?redirectUri=${pathname}`, request.url));
+    // Pass the unprefixed pathname + search so signin's router doesn't
+    // double-prefix and the original query string survives the round-trip
+    // (e.g. /games/import?source=lichess preserves ?source=lichess).
+    // encodeURIComponent preserves '&' and '#' inside the redirect target
+    // so the receiving signin route sees the full original path, not a
+    // fragment cut off at the first query-string separator.
+    const search = request.nextUrl.search;
+    return forwardIntlHeaders(
+        NextResponse.redirect(
+            new URL(
+                `${buildPath(locale, '/')}?redirectUri=${encodeURIComponent(pathname + search)}`,
+                request.url,
+            ),
+        ),
+    );
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

Switches next-intl to `localePrefix: 'as-needed'` so English URLs are bare (`/profile`) while German and pseudo keep their prefix (`/de/profile`, `/pseudo/profile`). Builds on the URL-prefixed-locales work merged via the `intl` branch.

Key changes:

- `proxy.ts` forwards next-intl's `x-middleware-rewrite` and `Set-Cookie` headers onto downstream responses, gated to non-redirect responses so a future Next honouring rewrite-on-redirect cannot double-redirect.
- `next.config.mjs` adds a 308 for `/en/* → /*`. next-intl's middleware emits a 307, which search engines do not honour for canonicalization; the Next-level 308 transfers SEO authority and cuts one middleware invocation per `/en/...` request.
- `sanitizeRedirectUri` switched from deny-list to allow-list, closing a backslash bypass (`/\evil.com`) for protocol-relative URLs. Covered by a new `sanitizeRedirectUri.test.ts`.
- Unauth signin redirect encodes `pathname + search`, so `/games/import?source=lichess` survives the round-trip.
- Locale cookie sets `Secure` when `NODE_ENV === 'production'`.
- Bare-path variants for the legacy redirects and the `pagesWithVideos` COEP overrides, since default-locale users no longer hit prefixed URLs.
- Bare-`/profile` Playwright spec asserts `response.status() === 200` and h1 visibility, so a broken `x-middleware-rewrite` forward fails the test.

## Related Issues

Refs #1997

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

- [x] New unit tests (vitest) were added (`sanitizeRedirectUri.test.ts`)
- [x] New playwright tests were added (assertion strengthening on `i18n/routing.spec.ts`, bare-path coverage on `landing.spec.ts` and `db-overlay.spec.ts`)
