### PR TITLE
fix(#1997): restore language in the profile editor update payload

### DIFF
--- a/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
@@ -129,7 +129,7 @@ function getUpdate(
         return undefined;
     }
 
-    return update as Partial<UserUpdate>;
+    return update;
 }
 export function encodeFileToBase64(file: File): Promise<string> {
     return new Promise<string>((resolve, reject) => {
@@ -188,6 +188,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
                 timezone === DefaultTimezone && !user.timezoneOverride
                     ? user.timezoneOverride
                     : timezone,
+            language: language === DEFAULT_LOCALE && !user.language ? user.language : language,
         },
         profilePictureData,
     );


### PR DESCRIPTION
## Summary
Changing only the language on /profile/edit no longer saves: the dev merge
(9a2ef9d2) rebuilt the editor around per-section saves (#2312) and `language`
fell out of the personal section's `getUpdate` fields. The Save button never
enables, and the value never reaches the API. This restores the field, using
the same guard as `timezoneOverride` so an unset `user.language` doesn't
register as a phantom change while the selector shows the default.

Also removes the `getUpdate` return cast flagged by this branch's Code
Quality CI (`no-unnecessary-type-assertion`, ProfileEditorPage.tsx:132).

Note: Code Quality has been red on intl since the dev merge (the regenerated
lockfile pulled newer typescript-eslint / react-compiler versions, which flag
~26 pre-existing spots branch-wide). This PR's file passes lint; the rest are
untouched. Happy to follow up with a cleanup PR if useful.

## Related Issues
Refs #1997

## Type of change
*   [x] Bug fix (non-breaking change which fixes an issue)

## Testing
* [x] It was not necessary to add tests due to the fix restoring an input field
  of a private helper; verified manually.