### PR TITLE
Feat/1750 delete orphaned activity entries

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -398,7 +398,11 @@
             "updateTitle": "Aktualisiere {name}?",
             "totalCount": "Gesamtanzahl: {totalCount}. Aktuelle Kohorte: {cohortCount}",
             "totalTime": "Gesamtzeit: {totalHours}h {totalMinutes}m. Aktuelle Kohorte: {cohortHours}h {cohortMinutes}m",
-            "restDayCleared": "Ruhetag gelöscht"
+            "restDayCleared": "Ruhetag gelöscht",
+            "deletedTaskTitle": "Aktivitätseintrag löschen?",
+            "deletedTaskDescription": "Dieser Eintrag bezieht sich auf eine gelöschte benutzerdefinierte Aufgabe. Möchtest du ihn aus deinem Aktivitätszeitstrahl entfernen?",
+            "deleteEntry": "Eintrag löschen",
+            "entryDeleted": "Aktivitätseintrag gelöscht"
         },
         "info": {
             "type": "Typ",

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -401,7 +401,7 @@
             "restDayCleared": "Ruhetag gelöscht",
             "deletedTaskTitle": "Aktivitätseintrag löschen?",
             "deletedTaskDescription": "Dieser Eintrag bezieht sich auf eine gelöschte benutzerdefinierte Aufgabe. Möchtest du ihn aus deinem Aktivitätszeitstrahl entfernen?",
-            "deleteEntry": "Eintrag löschen",
+            "deleteEntry": "Löschen",
             "entryDeleted": "Aktivitätseintrag gelöscht"
         },
         "info": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -401,7 +401,7 @@
             "restDayCleared": "Rest day cleared",
             "deletedTaskTitle": "Delete activity entry?",
             "deletedTaskDescription": "This entry references a custom task that has been deleted. Would you like to remove it from your activity timeline?",
-            "deleteEntry": "Delete entry",
+            "deleteEntry": "Delete",
             "entryDeleted": "Activity entry deleted"
         },
         "info": {

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -398,7 +398,11 @@
             "updateTitle": "Update {name}?",
             "totalCount": "Total Count: {totalCount}. Current Cohort: {cohortCount}",
             "totalTime": "Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
-            "restDayCleared": "Rest day cleared"
+            "restDayCleared": "Rest day cleared",
+            "deletedTaskTitle": "Delete activity entry?",
+            "deletedTaskDescription": "This entry references a custom task that has been deleted. Would you like to remove it from your activity timeline?",
+            "deleteEntry": "Delete entry",
+            "entryDeleted": "Activity entry deleted"
         },
         "info": {
             "type": "Type",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -401,7 +401,7 @@
             "restDayCleared": "Día de descanso eliminado",
             "deletedTaskTitle": "¿Eliminar entrada de actividad?",
             "deletedTaskDescription": "Esta entrada hace referencia a una tarea personalizada que ha sido eliminada. ¿Quieres eliminarla de tu cronología de actividad?",
-            "deleteEntry": "Eliminar entrada",
+            "deleteEntry": "Eliminar",
             "entryDeleted": "Entrada de actividad eliminada"
         },
         "info": {

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -398,7 +398,11 @@
             "updateTitle": "¿Actualizar {name}?",
             "totalCount": "Cantidad total: {totalCount}. Cohorte actual: {cohortCount}",
             "totalTime": "Tiempo total: {totalHours}h {totalMinutes}m. Cohorte actual: {cohortHours}h {cohortMinutes}m",
-            "restDayCleared": "Día de descanso eliminado"
+            "restDayCleared": "Día de descanso eliminado",
+            "deletedTaskTitle": "¿Eliminar entrada de actividad?",
+            "deletedTaskDescription": "Esta entrada hace referencia a una tarea personalizada que ha sido eliminada. ¿Quieres eliminarla de tu cronología de actividad?",
+            "deleteEntry": "Eliminar entrada",
+            "entryDeleted": "Entrada de actividad eliminada"
         },
         "info": {
             "type": "Tipo",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -401,7 +401,7 @@
             "restDayCleared": "Jour de repos supprimé",
             "deletedTaskTitle": "Supprimer l'entrée d'activité ?",
             "deletedTaskDescription": "Cette entrée fait référence à une tâche personnalisée qui a été supprimée. Veux-tu la retirer de ta chronologie d'activité ?",
-            "deleteEntry": "Supprimer l'entrée",
+            "deleteEntry": "Supprimer",
             "entryDeleted": "Entrée d'activité supprimée"
         },
         "info": {

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -398,7 +398,11 @@
             "updateTitle": "Mettre à jour {name} ?",
             "totalCount": "Nombre total : {totalCount}. Cohorte actuelle : {cohortCount}",
             "totalTime": "Temps total : {totalHours} h {totalMinutes} min. Cohorte actuelle : {cohortHours} h {cohortMinutes} min",
-            "restDayCleared": "Jour de repos supprimé"
+            "restDayCleared": "Jour de repos supprimé",
+            "deletedTaskTitle": "Supprimer l'entrée d'activité ?",
+            "deletedTaskDescription": "Cette entrée fait référence à une tâche personnalisée qui a été supprimée. Veux-tu la retirer de ta chronologie d'activité ?",
+            "deleteEntry": "Supprimer l'entrée",
+            "entryDeleted": "Entrée d'activité supprimée"
         },
         "info": {
             "type": "Type",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -398,7 +398,11 @@
             "updateTitle": "Aggiornare {name}?",
             "totalCount": "Conteggio totale: {totalCount}. Coorte attuale: {cohortCount}",
             "totalTime": "Tempo totale: {totalHours}h {totalMinutes}m. Coorte attuale: {cohortHours}h {cohortMinutes}m",
-            "restDayCleared": "Giorno di riposo annullato"
+            "restDayCleared": "Giorno di riposo annullato",
+            "deletedTaskTitle": "Eliminare la voce di attività?",
+            "deletedTaskDescription": "Questa voce fa riferimento a un compito personalizzato che è stato eliminato. Vuoi rimuoverla dalla cronologia delle tue attività?",
+            "deleteEntry": "Elimina voce",
+            "entryDeleted": "Voce di attività eliminata"
         },
         "info": {
             "type": "Tipo",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -401,7 +401,7 @@
             "restDayCleared": "Giorno di riposo annullato",
             "deletedTaskTitle": "Eliminare la voce di attività?",
             "deletedTaskDescription": "Questa voce fa riferimento a un compito personalizzato che è stato eliminato. Vuoi rimuoverla dalla cronologia delle tue attività?",
-            "deleteEntry": "Elimina voce",
+            "deleteEntry": "Elimina",
             "entryDeleted": "Voce di attività eliminata"
         },
         "info": {

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -401,7 +401,7 @@
             "restDayCleared": "[T] Rest day cleared",
             "deletedTaskTitle": "[T] Delete activity entry?",
             "deletedTaskDescription": "[T] This entry references a custom task that has been deleted. Would you like to remove it from your activity timeline?",
-            "deleteEntry": "[T] Delete entry",
+            "deleteEntry": "[T] Delete",
             "entryDeleted": "[T] Activity entry deleted"
         },
         "info": {

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -398,7 +398,11 @@
             "updateTitle": "[T] Update {name}?",
             "totalCount": "[T] Total Count: {totalCount}. Current Cohort: {cohortCount}",
             "totalTime": "[T] Total Time: {totalHours}h {totalMinutes}m. Current Cohort: {cohortHours}h {cohortMinutes}m",
-            "restDayCleared": "[T] Rest day cleared"
+            "restDayCleared": "[T] Rest day cleared",
+            "deletedTaskTitle": "[T] Delete activity entry?",
+            "deletedTaskDescription": "[T] This entry references a custom task that has been deleted. Would you like to remove it from your activity timeline?",
+            "deleteEntry": "[T] Delete entry",
+            "entryDeleted": "[T] Activity entry deleted"
         },
         "info": {
             "type": "[T] Type",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -398,7 +398,11 @@
             "updateTitle": "Atualizar {name}?",
             "totalCount": "Quantidade total: {totalCount}. Coorte atual: {cohortCount}",
             "totalTime": "Tempo total: {totalHours}h {totalMinutes}m. Coorte atual: {cohortHours}h {cohortMinutes}m",
-            "restDayCleared": "Dia de descanso removido"
+            "restDayCleared": "Dia de descanso removido",
+            "deletedTaskTitle": "Excluir entrada de atividade?",
+            "deletedTaskDescription": "Esta entrada faz referência a uma tarefa personalizada que foi excluída. Deseja removê-la da sua linha do tempo de atividade?",
+            "deleteEntry": "Excluir entrada",
+            "entryDeleted": "Entrada de atividade excluída"
         },
         "info": {
             "type": "Tipo",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -401,7 +401,7 @@
             "restDayCleared": "Dia de descanso removido",
             "deletedTaskTitle": "Excluir entrada de atividade?",
             "deletedTaskDescription": "Esta entrada faz referência a uma tarefa personalizada que foi excluída. Deseja removê-la da sua linha do tempo de atividade?",
-            "deleteEntry": "Excluir entrada",
+            "deleteEntry": "Excluir",
             "entryDeleted": "Entrada de atividade excluída"
         },
         "info": {

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
@@ -121,7 +121,7 @@ describe('EditTimelinEntryDialog (orphaned custom task)', () => {
         );
 
         expect(screen.getByText('Delete activity entry?')).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Delete entry' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
     });
 
     it('calls updateUserTimeline with the entry marked for deletion and notifies the parent on confirm', async () => {
@@ -135,7 +135,7 @@ describe('EditTimelinEntryDialog (orphaned custom task)', () => {
             />,
         );
 
-        fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
         await waitFor(() => {
             expect(updateUserTimeline).toHaveBeenCalledWith(

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
@@ -1,0 +1,147 @@
+import { useApi } from '@/api/Api';
+import { useRequirement } from '@/api/cache/requirements';
+import { useAuth } from '@/auth/Auth';
+import { TimelineEntry } from '@/database/timeline';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditTimelinEntryDialog } from './EditTimelineEntryDialog';
+
+vi.mock('@/api/Api', () => ({ useApi: vi.fn() }));
+vi.mock('@/api/cache/requirements', () => ({ useRequirement: vi.fn() }));
+vi.mock('@/auth/Auth', () => ({ useAuth: vi.fn() }));
+vi.mock('../trainingPlan/ProgressHistory', () => ({
+    ProgressHistoryItem: () => null,
+    useProgressHistoryEditor: () => ({
+        errors: {},
+        request: {
+            isLoading: () => false,
+            isSent: () => false,
+            isFailure: () => false,
+            status: 'idle',
+            data: undefined,
+            error: undefined,
+            onStart: vi.fn(),
+            onSuccess: vi.fn(),
+            onFailure: vi.fn(),
+            reset: vi.fn(),
+        },
+        isTimeOnly: false,
+        items: [],
+        cohortCount: 0,
+        cohortTime: 0,
+        totalCount: 0,
+        totalTime: 0,
+        getUpdateItem: () => vi.fn(),
+        getDeleteItem: () => vi.fn(),
+        onSubmit: vi.fn(),
+    }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const messages = require('../../../../messages/en.json') as Record<string, unknown>;
+
+function renderWithIntl(ui: React.ReactElement) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { NextIntlClientProvider } = require('next-intl') as {
+        NextIntlClientProvider: React.FC<{
+            locale: string;
+            messages: Record<string, unknown>;
+            children: React.ReactNode;
+        }>;
+    };
+    return render(
+        <NextIntlClientProvider locale='en' messages={messages}>
+            {ui}
+        </NextIntlClientProvider>,
+    );
+}
+
+function makeOrphanedCustomEntry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
+    return {
+        owner: 'user-1',
+        id: 'entry-1',
+        ownerDisplayName: 'Test User',
+        cohort: '1500-1600',
+        requirementId: 'custom-task-1',
+        requirementName: 'My deleted task',
+        isCustomRequirement: true,
+        totalCount: 1,
+        previousCount: 0,
+        newCount: 1,
+        dojoPoints: 0,
+        totalDojoPoints: 0,
+        minutesSpent: 30,
+        totalMinutesSpent: 30,
+        date: '2026-06-20T00:00:00Z',
+        createdAt: '2026-06-20T00:00:00Z',
+        notes: '',
+        comments: null,
+        reactions: null,
+    } as TimelineEntry;
+}
+
+describe('EditTimelinEntryDialog (orphaned custom task)', () => {
+    const updateUserTimeline = vi.fn();
+    const onClose = vi.fn();
+    const onDeleteEntry = vi.fn();
+
+    beforeEach(() => {
+        updateUserTimeline.mockResolvedValue({});
+        vi.mocked(useApi).mockReturnValue({
+            updateUserTimeline,
+        } as unknown as ReturnType<typeof useApi>);
+        vi.mocked(useAuth).mockReturnValue({
+            user: { customTasks: [], dojoCohort: '1500-1600' },
+        } as unknown as ReturnType<typeof useAuth>);
+        vi.mocked(useRequirement).mockReturnValue({
+            requirement: undefined,
+        } as unknown as ReturnType<typeof useRequirement>);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('renders the deleted-task dialog when the custom task no longer exists on the user', () => {
+        const entry = makeOrphanedCustomEntry();
+
+        renderWithIntl(
+            <EditTimelinEntryDialog
+                entry={entry}
+                onClose={onClose}
+                onDeleteEntry={onDeleteEntry}
+            />,
+        );
+
+        expect(screen.getByText('Delete activity entry?')).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Delete entry' })).toBeInTheDocument();
+    });
+
+    it('calls updateUserTimeline with the entry marked for deletion and notifies the parent on confirm', async () => {
+        const entry = makeOrphanedCustomEntry();
+
+        renderWithIntl(
+            <EditTimelinEntryDialog
+                entry={entry}
+                onClose={onClose}
+                onDeleteEntry={onDeleteEntry}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Delete entry' }));
+
+        await waitFor(() => {
+            expect(updateUserTimeline).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    requirementId: 'custom-task-1',
+                    deleted: [entry],
+                    updated: [],
+                }),
+            );
+        });
+        expect(onDeleteEntry).toHaveBeenCalledWith(entry);
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
@@ -78,6 +78,7 @@ function makeOrphanedCustomEntry(overrides: Partial<TimelineEntry> = {}): Timeli
         notes: '',
         comments: null,
         reactions: null,
+        ...overrides,
     } as TimelineEntry;
 }
 

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.test.tsx
@@ -10,8 +10,10 @@ import { EditTimelinEntryDialog } from './EditTimelineEntryDialog';
 vi.mock('@/api/Api', () => ({ useApi: vi.fn() }));
 vi.mock('@/api/cache/requirements', () => ({ useRequirement: vi.fn() }));
 vi.mock('@/auth/Auth', () => ({ useAuth: vi.fn() }));
-vi.mock('../trainingPlan/ProgressHistory', () => ({
+vi.mock('../trainingPlan/ProgressHistoryItem', () => ({
     ProgressHistoryItem: () => null,
+}));
+vi.mock('../trainingPlan/ProgressHistory', () => ({
     useProgressHistoryEditor: () => ({
         errors: {},
         request: {
@@ -32,8 +34,10 @@ vi.mock('../trainingPlan/ProgressHistory', () => ({
         cohortTime: 0,
         totalCount: 0,
         totalTime: 0,
-        getUpdateItem: () => vi.fn(),
-        getDeleteItem: () => vi.fn(),
+        updateItem: vi.fn(),
+        updateDraftItem: vi.fn(),
+        getDraftItem: () => undefined,
+        deleteItem: vi.fn(),
         onSubmit: vi.fn(),
     }),
 }));

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
@@ -42,6 +42,7 @@ export function EditTimelinEntryDialog({
     );
 
     const requirement = isCustom ? customTask : fetchedRequirement;
+    const isOrphanedEntry = isCustom && !customTask;
 
     const {
         errors,
@@ -64,6 +65,28 @@ export function EditTimelinEntryDialog({
     });
 
     const index = items.findIndex((v) => v.entry.id === entry.id);
+
+    const onDeleteOrphanedEntry = async () => {
+        deleteRequest.onStart();
+        try {
+            await api.updateUserTimeline({
+                requirementId: entry.requirementId,
+                progress: {
+                    requirementId: entry.requirementId,
+                    counts: {},
+                    minutesSpent: {},
+                    updatedAt: '',
+                },
+                updated: [],
+                deleted: [entry],
+            });
+            onDeleteEntry(entry);
+            deleteRequest.onSuccess(t('entryDeleted'));
+            onClose();
+        } catch (err) {
+            deleteRequest.onFailure(err);
+        }
+    };
 
     const onClearRestDay = async () => {
         deleteRequest.onStart();
@@ -105,6 +128,32 @@ export function EditTimelinEntryDialog({
                     </Button>
                     <Button loading={deleteRequest.isLoading()} onClick={onClearRestDay}>
                         {t('clearRestDay')}
+                    </Button>
+                </DialogActions>
+
+                <RequestSnackbar request={deleteRequest} />
+            </Dialog>
+        );
+    }
+
+    if (isOrphanedEntry) {
+        return (
+            <Dialog
+                open
+                onClose={deleteRequest.isLoading() ? undefined : onClose}
+                fullWidth
+                maxWidth='sm'
+            >
+                <DialogTitle>{t('deletedTaskTitle')}</DialogTitle>
+                <DialogContent>
+                    <Typography sx={{ mt: 1 }}>{t('deletedTaskDescription')}</Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button disabled={deleteRequest.isLoading()} onClick={onClose}>
+                        {t('cancel')}
+                    </Button>
+                    <Button loading={deleteRequest.isLoading()} onClick={onDeleteOrphanedEntry}>
+                        {t('deleteEntry')}
                     </Button>
                 </DialogActions>
 

--- a/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
+++ b/frontend/src/components/profile/activity/EditTimelineEntryDialog.tsx
@@ -152,7 +152,11 @@ export function EditTimelinEntryDialog({
                     <Button disabled={deleteRequest.isLoading()} onClick={onClose}>
                         {t('cancel')}
                     </Button>
-                    <Button loading={deleteRequest.isLoading()} onClick={onDeleteOrphanedEntry}>
+                    <Button
+                        color='error'
+                        loading={deleteRequest.isLoading()}
+                        onClick={onDeleteOrphanedEntry}
+                    >
                         {t('deleteEntry')}
                     </Button>
                 </DialogActions>


### PR DESCRIPTION
## Summary

When a user deleted a custom task from their training plan, any historical activity entries logged against that task became "orphaned" — the entry remained in the activity timeline, but clicking it opened an edit dialog that hung on a never-resolving spinner. Clicking Save did nothing (no XHR fired) because the underlying hook had nothing valid to submit.

This PR makes the dialog detect orphaned entries (custom task that no longer exists on the user record) and render a focused "Delete activity entry?" confirmation instead of the broken spinner. The new flow mirrors the existing rest-day clearance dialog in the same component.

## Related Issues

Fixes #1750 

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}} 

## Demo

<img width="1044" height="647" alt="deletingOrphanedCustomTask" src="https://github.com/user-attachments/assets/9ac5776a-eb0a-40a0-ad0f-a6952938a793" />

