### PR TITLE
fix(#2585): show CloudDB queue feedback

### DIFF
--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -3437,6 +3437,7 @@
             "chessDbColumnWinrate": "Gewinnrate",
             "chessDbColumnNote": "Hinweis",
             "queueAnalysisButton": "Warteschlangenanalyse",
+            "analysisQueued": "Analyse wurde in die Warteschlange eingereiht. Bitte später erneut prüfen.",
             "positionNotInChessDb": "Position nicht in ChessDB.",
             "chessCloudDatabaseLabel": "Schach-Cloud-Datenbank",
             "tabDojo": "Dojo",

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -3437,6 +3437,7 @@
             "chessDbColumnWinrate": "Winrate",
             "chessDbColumnNote": "Note",
             "queueAnalysisButton": "Queue Analysis",
+            "analysisQueued": "Analysis queued. Check back later.",
             "positionNotInChessDb": "Position not in ChessDB.",
             "chessCloudDatabaseLabel": "Chess Cloud Database",
             "tabDojo": "Dojo",

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -3437,6 +3437,7 @@
             "chessDbColumnWinrate": "% de victorias",
             "chessDbColumnNote": "Nota",
             "queueAnalysisButton": "Solicitar análisis",
+            "analysisQueued": "Análisis añadido a la cola. Vuelve a comprobarlo más tarde.",
             "positionNotInChessDb": "La posición no está en ChessDB.",
             "chessCloudDatabaseLabel": "Chess Cloud Database",
             "tabDojo": "Dojo",

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -3437,6 +3437,7 @@
             "chessDbColumnWinrate": "Taux de victoire",
             "chessDbColumnNote": "Remarque",
             "queueAnalysisButton": "Ajouter à la file d'analyse",
+            "analysisQueued": "Analyse ajoutée à la file d'attente. Revenez plus tard.",
             "positionNotInChessDb": "Position absente de ChessDB.",
             "chessCloudDatabaseLabel": "Chess Cloud Database",
             "tabDojo": "Dojo",

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -3437,6 +3437,7 @@
             "chessDbColumnWinrate": "Tasso di vittorie",
             "chessDbColumnNote": "Nota",
             "queueAnalysisButton": "Accoda analisi",
+            "analysisQueued": "Analisi aggiunta alla coda. Controlla di nuovo più tardi.",
             "positionNotInChessDb": "Posizione non presente in ChessDB.",
             "chessCloudDatabaseLabel": "Chess Cloud Database",
             "tabDojo": "Dojo",

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -3437,6 +3437,7 @@
             "chessDbColumnWinrate": "[T] Winrate",
             "chessDbColumnNote": "[T] Note",
             "queueAnalysisButton": "[T] Queue Analysis",
+            "analysisQueued": "[T] Analysis queued. Check back later.",
             "positionNotInChessDb": "[T] Position not in ChessDB.",
             "chessCloudDatabaseLabel": "[T] Chess Cloud Database",
             "tabDojo": "[T] Dojo",

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -3437,6 +3437,7 @@
             "chessDbColumnWinrate": "% de vitórias",
             "chessDbColumnNote": "Nota",
             "queueAnalysisButton": "Solicitar análise",
+            "analysisQueued": "Análise adicionada à fila. Verifique novamente mais tarde.",
             "positionNotInChessDb": "Posição não encontrada no ChessDB.",
             "chessCloudDatabaseLabel": "Chess Cloud Database",
             "tabDojo": "Dojo",

--- a/frontend/src/api/chessdbService.test.ts
+++ b/frontend/src/api/chessdbService.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+
+vi.mock('./axiosService', () => ({ axiosService: { get: mockGet } }));
+
+import { ChessDBService } from './chessdbService';
+
+const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+describe('ChessDBService', () => {
+    beforeEach(() => {
+        mockGet.mockReset();
+    });
+
+    it('does not queue analysis when a position is unavailable', async () => {
+        mockGet.mockResolvedValue({ data: { status: 'unknown', moves: [] } });
+        const service = new ChessDBService('https://example.test/cdb.php');
+        const queueAnalysis = vi.spyOn(service, 'queueAnalysis');
+
+        const result = await service.getAnalysis(fen);
+
+        expect(result).toEqual({ error: 'Position evaluation not available: unknown' });
+        expect(queueAnalysis).not.toHaveBeenCalled();
+        expect(mockGet).toHaveBeenCalledWith(
+            `https://example.test/cdb.php?action=queryall&board=${encodeURIComponent(fen)}&json=1`,
+        );
+    });
+});

--- a/frontend/src/api/chessdbService.ts
+++ b/frontend/src/api/chessdbService.ts
@@ -67,7 +67,6 @@ export class ChessDBService {
             const responseData = response.data;
 
             if (responseData.status !== 'ok') {
-                void this.queueAnalysis(fen);
                 return { error: `Position evaluation not available: ${responseData.status}` };
             }
 

--- a/frontend/src/board/pgn/explorer/ChessDb.test.tsx
+++ b/frontend/src/board/pgn/explorer/ChessDb.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import messages from '~/messages/en.json';
+import { ChessDBTab } from './ChessDb';
+
+vi.mock('@mui/icons-material', () => ({ Help: () => <span /> }));
+vi.mock('../../Board', () => ({ useReconcile: () => vi.fn() }));
+vi.mock('../PgnBoard', () => ({ useChess: () => ({ chess: undefined }) }));
+
+const baseProps = {
+    moves: [],
+    loading: false,
+    error: 'Position evaluation not available: unknown',
+    requestAnalysis: vi.fn(),
+};
+
+function renderTab(props: ComponentProps<typeof ChessDBTab>) {
+    return render(
+        <NextIntlClientProvider
+            locale='en'
+            messages={{ analysisBoard: { explorer: messages.analysisBoard.explorer } }}
+        >
+            <ChessDBTab {...props} />
+        </NextIntlClientProvider>,
+    );
+}
+
+describe('ChessDBTab queue feedback', () => {
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('disables the queue button while the request is in flight', () => {
+        renderTab({ ...baseProps, queueing: true, queued: false });
+
+        expect(screen.getByRole('button', { name: 'Queue Analysis' })).toBeDisabled();
+    });
+
+    it('shows a confirmation instead of another button after queueing', () => {
+        renderTab({ ...baseProps, error: null, queueing: false, queued: true });
+
+        expect(screen.getByText('Analysis queued. Check back later.')).toBeVisible();
+        expect(screen.queryByRole('button', { name: 'Queue Analysis' })).not.toBeInTheDocument();
+    });
+});

--- a/frontend/src/board/pgn/explorer/ChessDb.tsx
+++ b/frontend/src/board/pgn/explorer/ChessDb.tsx
@@ -18,10 +18,19 @@ interface ChessDBTabProps {
     moves: ChessDbMove[];
     loading: boolean;
     error: string | null;
-    requestAnalysis: (fen: string) => void;
+    queueing: boolean;
+    queued: boolean;
+    requestAnalysis: () => void;
 }
 
-export function ChessDBTab({ moves, loading, error, requestAnalysis }: ChessDBTabProps) {
+export function ChessDBTab({
+    moves,
+    loading,
+    error,
+    queueing,
+    queued,
+    requestAnalysis,
+}: ChessDBTabProps) {
     const { chess } = useChess();
     const reconcile = useReconcile();
     const t = useTranslations('analysisBoard.explorer');
@@ -67,12 +76,21 @@ export function ChessDBTab({ moves, loading, error, requestAnalysis }: ChessDBTa
 
     if (loading) return <LoadingPage />;
 
+    if (queued) {
+        return (
+            <Stack mt={2} spacing={1} alignItems='center'>
+                <Typography color='success.main'>{t('analysisQueued')}</Typography>
+            </Stack>
+        );
+    }
+
     if (error) {
         return (
             <Stack mt={2} spacing={1} alignItems='center'>
                 <Typography color='error'>{error}</Typography>
                 <Button
-                    onClick={() => requestAnalysis(chess?.fen() ?? '')}
+                    onClick={requestAnalysis}
+                    loading={queueing}
                     variant='outlined'
                     size='small'
                 >
@@ -87,7 +105,8 @@ export function ChessDBTab({ moves, loading, error, requestAnalysis }: ChessDBTa
             <Stack mt={2} spacing={1} alignItems='center'>
                 <Typography>{t('positionNotInChessDb')}</Typography>
                 <Button
-                    onClick={() => requestAnalysis(chess?.fen() ?? '')}
+                    onClick={requestAnalysis}
+                    loading={queueing}
                     variant='outlined'
                     size='small'
                 >

--- a/frontend/src/board/pgn/explorer/Explorer.test.tsx
+++ b/frontend/src/board/pgn/explorer/Explorer.test.tsx
@@ -37,6 +37,8 @@ vi.mock('@/stockfish/hooks/useChessDb', () => ({
         data: [],
         loading: false,
         error: null,
+        queueing: false,
+        queued: false,
         queueAnalysis: vi.fn(),
     }),
 }));

--- a/frontend/src/board/pgn/explorer/Explorer.tsx
+++ b/frontend/src/board/pgn/explorer/Explorer.tsx
@@ -78,6 +78,8 @@ const Explorer: React.FC<ExplorerProps> = ({ storageKey = explorerTabKey }) => {
         data: chessDbMoves,
         loading: chessDbLoading,
         error: chessDbError,
+        queueing: chessDbQueueing,
+        queued: chessDbQueued,
         queueAnalysis: chessDbRequestAnalysis,
     } = useChessDB({ enableMoves: true, enablePv: false });
 
@@ -147,6 +149,8 @@ const Explorer: React.FC<ExplorerProps> = ({ storageKey = explorerTabKey }) => {
                         moves={chessDbMoves}
                         loading={chessDbLoading}
                         error={chessDbError}
+                        queueing={chessDbQueueing}
+                        queued={chessDbQueued}
                         requestAnalysis={() => chessDbRequestAnalysis(fen)}
                     />
                 );

--- a/frontend/src/stockfish/hooks/useChessDb.test.tsx
+++ b/frontend/src/stockfish/hooks/useChessDb.test.tsx
@@ -1,0 +1,105 @@
+import { ChessDBService } from '@/api/chessdbService';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useChessDB } from './useChessDb';
+
+const { getChessDbCache, setChessDbCacheEntry } = vi.hoisted(() => ({
+    getChessDbCache: vi.fn(),
+    setChessDbCacheEntry: vi.fn(),
+}));
+
+vi.mock('@/api/cache/chessdb', () => ({ getChessDbCache, setChessDbCacheEntry }));
+vi.mock('@/board/pgn/PgnBoard', () => ({ useChess: () => ({ chess: undefined }) }));
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+
+const fen = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+const otherFen = 'rnbqkbnr/pppp1ppp/8/4p3/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 2';
+
+describe('useChessDB queue analysis', () => {
+    beforeEach(() => {
+        getChessDbCache.mockReset();
+        getChessDbCache.mockResolvedValue(undefined);
+        setChessDbCacheEntry.mockReset();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('does not queue when an analysis lookup is unavailable', async () => {
+        vi.spyOn(ChessDBService.prototype, 'getAnalysis').mockResolvedValue({
+            error: 'Position evaluation not available: unknown',
+        });
+        const queueAnalysis = vi
+            .spyOn(ChessDBService.prototype, 'queueAnalysis')
+            .mockResolvedValue({ success: true });
+        const { result } = renderHook(() => useChessDB({ enableMoves: false, enablePv: false }));
+
+        await act(async () => {
+            await result.current.fetchChessDBData(fen, true);
+        });
+
+        expect(queueAnalysis).not.toHaveBeenCalled();
+        expect(result.current.error).toBe('Position evaluation not available: unknown');
+    });
+
+    it('shows queueing until an explicit queue request succeeds', async () => {
+        let resolveQueue!: (value: { success: boolean }) => void;
+        const response = new Promise<{ success: boolean }>((resolve) => {
+            resolveQueue = resolve;
+        });
+        vi.spyOn(ChessDBService.prototype, 'queueAnalysis').mockReturnValue(response);
+        const { result } = renderHook(() => useChessDB({ enableMoves: false, enablePv: false }));
+        let request!: Promise<void>;
+
+        act(() => {
+            request = result.current.queueAnalysis(fen);
+        });
+
+        expect(result.current.queueing).toBe(true);
+        expect(result.current.queued).toBe(false);
+
+        await act(async () => {
+            resolveQueue({ success: true });
+            await request;
+        });
+
+        expect(result.current.queueing).toBe(false);
+        expect(result.current.queued).toBe(true);
+        expect(result.current.error).toBeNull();
+    });
+
+    it('surfaces a returned queue error and remains retryable', async () => {
+        vi.spyOn(ChessDBService.prototype, 'queueAnalysis').mockResolvedValue({
+            error: 'Failed to queue position: limit',
+        });
+        const { result } = renderHook(() => useChessDB({ enableMoves: false, enablePv: false }));
+
+        await act(async () => {
+            await result.current.queueAnalysis(fen);
+        });
+
+        expect(result.current.queueing).toBe(false);
+        expect(result.current.queued).toBe(false);
+        expect(result.current.error).toBe('Failed to queue position: limit');
+    });
+
+    it('clears queued confirmation before fetching another position', async () => {
+        vi.spyOn(ChessDBService.prototype, 'queueAnalysis').mockResolvedValue({ success: true });
+        vi.spyOn(ChessDBService.prototype, 'getAnalysis').mockResolvedValue({
+            error: 'Position evaluation not available: unknown',
+        });
+        const { result } = renderHook(() => useChessDB({ enableMoves: false, enablePv: false }));
+
+        await act(async () => {
+            await result.current.queueAnalysis(fen);
+        });
+        expect(result.current.queued).toBe(true);
+
+        await act(async () => {
+            await result.current.fetchChessDBData(otherFen, true);
+        });
+
+        expect(result.current.queued).toBe(false);
+    });
+});

--- a/frontend/src/stockfish/hooks/useChessDb.ts
+++ b/frontend/src/stockfish/hooks/useChessDb.ts
@@ -27,6 +27,7 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [queueing, setQueueing] = useState(false);
+    const [queued, setQueued] = useState(false);
     const [pv, setPv] = useState<ChessDbPv | null>(null);
     const [pvLoading, setPvLoading] = useState(false);
 
@@ -36,9 +37,16 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
         async (fenString: string): Promise<void> => {
             if (!fenString.trim() || !validateFen(fenString)) return;
 
+            setQueueing(true);
+            setQueued(false);
+            setError(null);
+
             try {
-                setQueueing(true);
-                await chessDbService.queueAnalysis(fenString);
+                const result = await chessDbService.queueAnalysis(fenString);
+                if (result.error) {
+                    throw new Error(result.error);
+                }
+                setQueued(true);
             } catch (err) {
                 setError(err instanceof Error ? err.message : t('failedToQueueAnalysis'));
             } finally {
@@ -83,6 +91,7 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
 
     const fetchChessDBData = useCallback(
         async (fenString: string, enabled: boolean) => {
+            setQueued(false);
             if (!fenString.trim()) {
                 setData([]);
                 setError(null);
@@ -112,7 +121,6 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
                     await setChessDbCacheEntry(fenString, { moves: chessDbMoves.data.moves });
                     setData(chessDbMoves.data.moves);
                 } else {
-                    await queueAnalysis(fenString);
                     throw new Error(chessDbMoves.error);
                 }
             } catch (err) {
@@ -122,7 +130,7 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
                 setLoading(false);
             }
         },
-        [queueAnalysis, chessDbService, t],
+        [chessDbService, t],
     );
 
     useEffect(() => {
@@ -148,6 +156,7 @@ export function useChessDB({ enableMoves, enablePv }: { enableMoves: boolean; en
         loading,
         error,
         queueing,
+        queued,
         fetchChessDBData,
         queueAnalysis,
         pv,


### PR DESCRIPTION
## Summary

Improves feedback for the CloudDB Queue Analysis action.

 Previously, clicking Queue Analysis appeared to do nothing because the interface provided no loading, success, or error feedback.    
 This PR makes queueing an explicit user action and shows clear feedback while the request is running and after it succeeds or fails.

## Related Issues

Fixes #2585

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests

## Demo

**Succes example after button click**
<img width="751" height="763" alt="image" src="https://github.com/user-attachments/assets/8be7dbdb-50ac-41b6-af6e-f7584250790e" />
