### PR TITLE
fix(#2446): resume guarded navigation after saving analysis

### DIFF
--- a/frontend/src/app/[locale]/(scoreboard)/games/analysis/AnalysisBoard.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/games/analysis/AnalysisBoard.tsx
@@ -198,21 +198,14 @@ export default function AnalysisBoard() {
 
             <Dialog
                 data-testid='unsaved-analysis-nav-guard'
-                open={navGuard.active}
+                open={navGuard.active && !showSaveDialog}
                 onClose={navGuard.reject}
             >
                 <DialogTitle>{t('saveTitle')}</DialogTitle>
                 <DialogContent>{t('unsavedWarning')}</DialogContent>
                 <DialogActions>
                     <Button onClick={navGuard.reject}>{t('cancel')}</Button>
-                    <Button
-                        onClick={() => {
-                            navGuard.reject();
-                            setShowSaveDialog(true);
-                        }}
-                    >
-                        {t('save')}
-                    </Button>
+                    <Button onClick={() => setShowSaveDialog(true)}>{t('save')}</Button>
                     <Button color='error' onClick={navGuard.accept}>
                         {t('delete')}
                     </Button>
@@ -225,8 +218,11 @@ export default function AnalysisBoard() {
                     open={showSaveDialog}
                     title={t('saveAnalysis')}
                     loading={request.isLoading()}
-                    onSubmit={onSubmit}
-                    onClose={() => setShowSaveDialog(false)}
+                    onSubmit={(form) => onSubmit(form, navGuard.accept)}
+                    onClose={() => {
+                        navGuard.reject();
+                        setShowSaveDialog(false);
+                    }}
                     createGameRequest={stagedGame}
                 />
             )}

--- a/frontend/src/hooks/useSaveGame.ts
+++ b/frontend/src/hooks/useSaveGame.ts
@@ -17,7 +17,7 @@ import { useSessionStorage } from 'usehooks-ts';
 const STAGED_CREATE_GAME_KEY = 'useSaveGame:stageCreateGame';
 
 export interface UseSaveGameFields {
-    createGame: (req: CreateGameRequest) => Promise<void>;
+    createGame: (req: CreateGameRequest, onNavigate?: () => void) => Promise<void>;
     updateGame: (req: UpdateGameRequest) => Promise<void>;
     setStagedGame: (req: CreateGameRequest) => void;
     stagedGame: CreateGameRequest | null;
@@ -34,11 +34,11 @@ export default function useSaveGame(): UseSaveGameFields {
     const { game } = useGame();
     const router = useRouter();
 
-    const createGame = async (createReq: CreateGameRequest) => {
+    const createGame = async (createReq: CreateGameRequest, onNavigate?: () => void) => {
         request.onStart();
         try {
             const response = await api.createGame(createReq);
-            onCreateGame(createReq, response.data, router);
+            onCreateGame(createReq, response.data, router, onNavigate);
 
             if (isGame(response.data)) {
                 request.onSuccess();
@@ -78,6 +78,7 @@ function onCreateGame(
     req: CreateGameRequest,
     data: Game | EditGameResponse,
     router: AppRouterInstance,
+    onNavigate?: () => void,
 ) {
     if (isGame(data)) {
         const game = data;
@@ -85,6 +86,11 @@ function onCreateGame(
             count: 1,
             method: req.type,
         });
+
+        if (onNavigate) {
+            onNavigate();
+            return;
+        }
 
         const urlSafeId = game.id.replaceAll('?', '%3F');
         let newUrl = `/games/${game.cohort.replaceAll('+', '%2B')}/${urlSafeId}`;

--- a/frontend/src/hooks/useUnsavedGame.ts
+++ b/frontend/src/hooks/useUnsavedGame.ts
@@ -19,7 +19,7 @@ export function useUnsavedGame(chessProp?: Chess) {
     const { chess: chessContext } = useChess();
 
     const chess = chessProp ?? chessContext;
-    const onSubmit = async (form: SaveGameForm) => {
+    const onSubmit = async (form: SaveGameForm, onNavigate?: () => void) => {
         if (!chess) {
             return;
         }
@@ -45,7 +45,7 @@ export function useUnsavedGame(chessProp?: Chess) {
             req.directory = undefined;
         }
 
-        await createGame(req).then(() => {
+        await createGame(req, onNavigate).then(() => {
             setShowDialog(false);
         });
     };


### PR DESCRIPTION
## Summary

When you are in analysis and, after having input enough moves (more than 5) want to navigate to another page, after choosing to save and completing the save form, the navigation does not proceed to the selected page, but always went to the newly created game in the games section.
With this PR, after saving the analysis, the navigation proceeds to the page the user intended to go to.

## Related Issues

Fixes #2446

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

It was not necessary to add tests — verified manually across all guard
  paths: Save resumes navigation to the intended page; Cancel and Delete
  unchanged; backing out of the save dialog stays on the analysis; direct
  save via the unsaved-game banner still redirects to the new game's page.
  Existing AnalysisBoard unit tests and the playwright nav-guard test pass
  unchanged.

## Demo

No new or modified pages to be shown
