### PR TITLE
feat: revamp blog comment UI with 3-dots menu

### DIFF
--- a/frontend/src/app/[locale]/(blog)/blog/[...id]/BlogComments.tsx
+++ b/frontend/src/app/[locale]/(blog)/blog/[...id]/BlogComments.tsx
@@ -51,6 +51,7 @@ export default function BlogComments({ comments: initialComments, owner, id }: B
                 onDelete={user ? handleDelete : undefined}
                 threaded
                 onSubmitReply={user ? handleSubmitReply : undefined}
+                outlined
             />
             {user ? (
                 <CommentEditor<Blog, { owner: string; id: string }>

--- a/frontend/src/components/comments/CommentList.test.tsx
+++ b/frontend/src/components/comments/CommentList.test.tsx
@@ -292,4 +292,64 @@ describe('CommentList', () => {
             expect(screen.getByText('Show 1 more reply')).toBeInTheDocument();
         });
     });
+
+    describe('Comment actions menu', () => {
+        it('shows edit and delete actions in an overflow menu for the comment owner', () => {
+            renderWithIntl(
+                <CommentList
+                    comments={[makeComment({ owner: mockUser.username })]}
+                    onEdit={vi.fn().mockResolvedValue(undefined)}
+                    onDelete={vi.fn().mockResolvedValue(undefined)}
+                />,
+            );
+
+            expect(screen.queryByRole('menuitem', { name: 'Edit' })).not.toBeInTheDocument();
+            fireEvent.click(screen.getByRole('button', { name: 'Edit / Delete' }));
+
+            expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument();
+            expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+        });
+
+        it('starts editing and closes the overflow menu', () => {
+            renderWithIntl(
+                <CommentList
+                    comments={[makeComment({ owner: mockUser.username })]}
+                    onEdit={vi.fn().mockResolvedValue(undefined)}
+                />,
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+            fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+
+            expect(screen.getByRole('textbox')).toHaveValue('Test comment');
+            expect(screen.queryByRole('menuitem', { name: 'Edit' })).not.toBeInTheDocument();
+        });
+
+        it('opens the existing confirmation dialog from the delete action', () => {
+            renderWithIntl(
+                <CommentList
+                    comments={[makeComment({ owner: mockUser.username })]}
+                    onDelete={vi.fn().mockResolvedValue(undefined)}
+                />,
+            );
+
+            fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+            fireEvent.click(screen.getByRole('menuitem', { name: 'Delete' }));
+
+            expect(screen.getByRole('dialog', { name: 'Delete Comment' })).toBeInTheDocument();
+            expect(screen.queryByRole('menuitem', { name: 'Delete' })).not.toBeInTheDocument();
+        });
+
+        it('does not show comment actions to another user', () => {
+            renderWithIntl(
+                <CommentList
+                    comments={[makeComment()]}
+                    onEdit={vi.fn().mockResolvedValue(undefined)}
+                    onDelete={vi.fn().mockResolvedValue(undefined)}
+                />,
+            );
+
+            expect(screen.queryByRole('button', { name: 'Edit / Delete' })).not.toBeInTheDocument();
+        });
+    });
 });

--- a/frontend/src/components/comments/CommentList.tsx
+++ b/frontend/src/components/comments/CommentList.tsx
@@ -7,6 +7,7 @@ import { Comment } from '@jackstenglein/chess-dojo-common/src/database/timeline'
 import CloseIcon from '@mui/icons-material/Close';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
 import ReplyIcon from '@mui/icons-material/Reply';
 import SaveIcon from '@mui/icons-material/Save';
 import SendIcon from '@mui/icons-material/Send';
@@ -18,6 +19,9 @@ import {
     DialogContentText,
     DialogTitle,
     IconButton,
+    ListItemIcon,
+    Menu,
+    MenuItem,
     Paper,
     Stack,
     TextField,
@@ -39,6 +43,7 @@ interface CommentListProps {
     onDelete?: (commentId: string) => Promise<void>;
     threaded?: boolean;
     onSubmitReply?: (parentId: string, content: string) => Promise<void>;
+    outlined?: boolean;
 }
 
 const CommentList: React.FC<CommentListProps> = ({
@@ -49,6 +54,7 @@ const CommentList: React.FC<CommentListProps> = ({
     onDelete,
     threaded,
     onSubmitReply,
+    outlined,
 }) => {
     const t = useTranslations('comments');
     const [replyingTo, setReplyingTo] = useState<string | null>(null);
@@ -123,6 +129,7 @@ const CommentList: React.FC<CommentListProps> = ({
                                 onEdit={onEdit}
                                 onDelete={onDelete}
                                 onReply={onSubmitReply ? handleReplyClick : undefined}
+                                outlined={outlined}
                             />
                             {replyingTo === thread.root.id && onSubmitReply && (
                                 <InlineReplyEditor
@@ -166,6 +173,7 @@ const CommentList: React.FC<CommentListProps> = ({
                                         onEdit={onEdit}
                                         onDelete={onDelete}
                                         onReply={onSubmitReply ? handleReplyClick : undefined}
+                                        outlined={outlined}
                                     />
                                     {replyingTo === reply.id && onSubmitReply && (
                                         <InlineReplyEditor
@@ -205,6 +213,7 @@ const CommentList: React.FC<CommentListProps> = ({
                     comment={comment}
                     onEdit={onEdit}
                     onDelete={onDelete}
+                    outlined={outlined}
                 />
             ))}
         </Stack>
@@ -216,6 +225,7 @@ interface CommentListItemProps {
     onEdit?: (commentId: string, content: string) => Promise<void>;
     onDelete?: (commentId: string) => Promise<void>;
     onReply?: (parentCommentId: string) => void;
+    outlined?: boolean;
 }
 
 const CommentListItem: React.FC<CommentListItemProps> = ({
@@ -223,6 +233,7 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
     onEdit,
     onDelete,
     onReply,
+    outlined,
 }) => {
     const t = useTranslations('comments');
     const { user } = useAuth();
@@ -231,6 +242,7 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
     const [expanded, setExpanded] = useState(false);
     const [isClamped, setIsClamped] = useState(false);
     const contentRef = useRef<HTMLElement>(null);
+    const [actionsAnchorEl, setActionsAnchorEl] = useState<HTMLElement | null>(null);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
     const editRequest = useRequest();
     const deleteRequest = useRequest();
@@ -253,6 +265,19 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
     const timeFormat = user?.timeFormat;
 
     const canModify = (onEdit || onDelete) && (user?.username === comment.owner || user?.isAdmin);
+    const actionsLabel = [onEdit && t('edit'), onDelete && t('delete')].filter(Boolean).join(' / ');
+
+    const handleEditClick = () => {
+        setActionsAnchorEl(null);
+        setEditContent(comment.content);
+        setEditing(true);
+    };
+
+    const handleDeleteClick = () => {
+        setActionsAnchorEl(null);
+        deleteRequest.reset();
+        setDeleteDialogOpen(true);
+    };
 
     const handleSaveEdit = () => {
         const content = editContent.trim();
@@ -293,7 +318,19 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
             <Avatar username={comment.owner} displayName={comment.ownerDisplayName} size={40} />
 
             <Stack flexGrow={1} minWidth={0}>
-                <Paper elevation={2} sx={{ px: '12px', py: '8px', borderRadius: '6px' }}>
+                <Paper
+                    elevation={2}
+                    sx={{
+                        px: '12px',
+                        py: '8px',
+                        borderRadius: '6px',
+                        ...(outlined && {
+                            border: 1,
+                            borderColor: 'divider',
+                            boxShadow: 'none',
+                        }),
+                    }}
+                >
                     <Stack>
                         <Stack direction='row' justifyContent='space-between' alignItems='center'>
                             <Link href={`/profile/${comment.owner}`}>
@@ -303,34 +340,20 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
                             </Link>
 
                             {canModify && !editing && (
-                                <Stack direction='row' spacing={0.5}>
-                                    {onEdit && (
-                                        <Tooltip title={t('edit')}>
-                                            <IconButton
-                                                size='small'
-                                                onClick={() => {
-                                                    setEditContent(comment.content);
-                                                    setEditing(true);
-                                                }}
-                                            >
-                                                <EditIcon fontSize='small' />
-                                            </IconButton>
-                                        </Tooltip>
-                                    )}
-                                    {onDelete && (
-                                        <Tooltip title={t('delete')}>
-                                            <IconButton
-                                                size='small'
-                                                onClick={() => {
-                                                    deleteRequest.reset();
-                                                    setDeleteDialogOpen(true);
-                                                }}
-                                            >
-                                                <DeleteIcon fontSize='small' />
-                                            </IconButton>
-                                        </Tooltip>
-                                    )}
-                                </Stack>
+                                <IconButton
+                                    size='small'
+                                    aria-label={actionsLabel}
+                                    aria-controls={
+                                        actionsAnchorEl
+                                            ? `comment-actions-${comment.id}`
+                                            : undefined
+                                    }
+                                    aria-haspopup='menu'
+                                    aria-expanded={actionsAnchorEl ? 'true' : undefined}
+                                    onClick={(event) => setActionsAnchorEl(event.currentTarget)}
+                                >
+                                    <MoreVertIcon fontSize='small' />
+                                </IconButton>
                             )}
                         </Stack>
 
@@ -414,7 +437,13 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
                         )}
                     </Stack>
                 </Paper>
-                <Stack direction='row' alignItems='center' spacing={1}>
+                <Stack
+                    direction='row'
+                    alignItems='center'
+                    spacing={1}
+                    mt={outlined ? 0.25 : undefined}
+                    px={outlined ? 0.5 : undefined}
+                >
                     <Typography variant='caption' color='text.secondary'>
                         {toDojoDateString(createdAt, timezone)} •{' '}
                         {toDojoTimeString(createdAt, timezone, timeFormat)}
@@ -422,6 +451,32 @@ const CommentListItem: React.FC<CommentListItemProps> = ({
                     </Typography>
                 </Stack>
             </Stack>
+
+            <Menu
+                id={`comment-actions-${comment.id}`}
+                anchorEl={actionsAnchorEl}
+                open={Boolean(actionsAnchorEl)}
+                onClose={() => setActionsAnchorEl(null)}
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+                {onEdit && (
+                    <MenuItem onClick={handleEditClick}>
+                        <ListItemIcon>
+                            <EditIcon fontSize='small' />
+                        </ListItemIcon>
+                        {t('edit')}
+                    </MenuItem>
+                )}
+                {onDelete && (
+                    <MenuItem onClick={handleDeleteClick} sx={{ color: 'error.main' }}>
+                        <ListItemIcon>
+                            <DeleteIcon fontSize='small' color='error' />
+                        </ListItemIcon>
+                        {t('delete')}
+                    </MenuItem>
+                )}
+            </Menu>
 
             <Dialog open={deleteDialogOpen} onClose={() => setDeleteDialogOpen(false)}>
                 <DialogTitle>{t('deleteComment')}</DialogTitle>


### PR DESCRIPTION
## Summary

revamped blog comments ui. swapped the floating edit/delete buttons for a 3-dot  menu and added outlined borders to comments to make the section look cleaner

## Related Issues

Closes #2591 

## Demo

<img width="715" height="546" alt="image" src="https://github.com/user-attachments/assets/2631ff9c-4b9d-4301-aad8-9f2174e9edb7" />
