### PR TITLE
fix: prevent owned game autosave races

### DIFF
--- a/frontend/src/board/pgn/boardTools/boardButtons/StatusIcon.test.tsx
+++ b/frontend/src/board/pgn/boardTools/boardButtons/StatusIcon.test.tsx
@@ -1,0 +1,159 @@
+import { useApi } from '@/api/Api';
+import { useRequest } from '@/api/Request';
+import { useAuth } from '@/auth/Auth';
+import { useReconcile } from '@/board/Board';
+import { useChess } from '@/board/pgn/PgnBoard';
+import useGame from '@/context/useGame';
+import { Game } from '@/database/game';
+import { EventType as ChessEventType, Observer } from '@jackstenglein/chess';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import StatusIcon from './StatusIcon';
+
+vi.mock('@/analytics/events', () => ({
+    EventType: { UpdateGame: 'UpdateGame' },
+    trackEvent: vi.fn(),
+}));
+vi.mock('@/api/Api', () => ({ useApi: vi.fn() }));
+vi.mock('@/api/Request', () => ({
+    RequestSnackbar: () => null,
+    useRequest: vi.fn(),
+}));
+vi.mock('@/auth/Auth', () => ({ useAuth: vi.fn() }));
+vi.mock('@/board/Board', () => ({ useReconcile: vi.fn() }));
+vi.mock('@/board/pgn/PgnBoard', () => ({ useChess: vi.fn() }));
+vi.mock('@/components/calendar/displayDate', () => ({
+    toDojoDateString: vi.fn(() => 'date'),
+    toDojoTimeString: vi.fn(() => 'time'),
+}));
+vi.mock('@/context/useGame', () => ({ default: vi.fn() }));
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+
+interface Deferred<T> {
+    promise: Promise<T>;
+    resolve: (value: T) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((res) => {
+        resolve = res;
+    });
+    return { promise, resolve };
+}
+
+const game = {
+    cohort: '1500-1600',
+    id: 'game-id',
+    updatedAt: '2026-08-26T12:00:00Z',
+} as Game;
+
+describe('StatusIcon autosave', () => {
+    let pgn: string;
+    let observer: Observer;
+    let requests: Deferred<{ data: { updatedAt: string } }>[];
+    const updateGame = vi.fn();
+    const setHasUnsavedGameChanges = vi.fn();
+    const updatedAtRef = { current: game.updatedAt };
+    const request = {
+        data: undefined,
+        onStart: vi.fn(),
+        onSuccess: vi.fn(),
+        onFailure: vi.fn(),
+        isLoading: vi.fn(() => false),
+        isFailure: vi.fn(() => false),
+    };
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        pgn = 'PGN 0';
+        requests = [];
+        updatedAtRef.current = game.updatedAt;
+        updateGame.mockImplementation(() => {
+            const result = deferred<{ data: { updatedAt: string } }>();
+            requests.push(result);
+            return result.promise;
+        });
+
+        vi.mocked(useApi).mockReturnValue({ updateGame } as unknown as ReturnType<typeof useApi>);
+        vi.mocked(useRequest).mockReturnValue(request as unknown as ReturnType<typeof useRequest>);
+        vi.mocked(useAuth).mockReturnValue({ user: undefined } as ReturnType<typeof useAuth>);
+        vi.mocked(useReconcile).mockReturnValue(vi.fn());
+        vi.mocked(useChess).mockReturnValue({
+            chess: {
+                renderPgn: () => pgn,
+                addObserver: vi.fn((value: Observer) => {
+                    observer = value;
+                }),
+                removeObserver: vi.fn(),
+            } as unknown as ReturnType<typeof useChess>['chess'],
+        });
+        vi.mocked(useGame).mockReturnValue({
+            updatedAtRef,
+            setHasUnsavedGameChanges,
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+        vi.useRealTimers();
+    });
+
+    const editGame = (nextPgn: string) => {
+        pgn = nextPgn;
+        act(() => observer.handler({ type: ChessEventType.UpdateComment }));
+    };
+
+    const runDebounce = () => {
+        act(() => {
+            vi.advanceTimersByTime(6000);
+        });
+    };
+
+    it('remains dirty when the board changes while an autosave is in progress', async () => {
+        render(<StatusIcon game={game} />);
+
+        editGame('PGN A');
+        runDebounce();
+        expect(updateGame).toHaveBeenCalledTimes(1);
+
+        editGame('PGN B');
+        await act(async () => {
+            requests[0].resolve({ data: { updatedAt: 'timestamp-a' } });
+            await Promise.resolve();
+        });
+
+        expect(setHasUnsavedGameChanges).toHaveBeenLastCalledWith(true);
+        expect(updateGame).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits for the active autosave before saving the latest PGN', async () => {
+        render(<StatusIcon game={game} />);
+
+        editGame('PGN A');
+        runDebounce();
+        editGame('PGN B');
+        runDebounce();
+
+        expect(updateGame).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            requests[0].resolve({ data: { updatedAt: 'timestamp-a' } });
+            await Promise.resolve();
+        });
+
+        expect(updateGame).toHaveBeenCalledTimes(2);
+        expect(updateGame).toHaveBeenLastCalledWith(game.cohort, game.id, {
+            type: 'editor',
+            pgnText: 'PGN B',
+            updatedAt: 'timestamp-a',
+        });
+
+        await act(async () => {
+            requests[1].resolve({ data: { updatedAt: 'timestamp-b' } });
+            await Promise.resolve();
+        });
+        expect(setHasUnsavedGameChanges).toHaveBeenLastCalledWith(false);
+    });
+});

--- a/frontend/src/board/pgn/boardTools/boardButtons/StatusIcon.tsx
+++ b/frontend/src/board/pgn/boardTools/boardButtons/StatusIcon.tsx
@@ -40,6 +40,13 @@ interface UndoLog {
     pgn: string;
 }
 
+interface PendingSave {
+    cohort: string;
+    id: string;
+    pgnText: string;
+    isUndo?: boolean;
+}
+
 interface StatusIconProps {
     game: Game;
 }
@@ -49,7 +56,9 @@ const StatusIcon: React.FC<StatusIconProps> = ({ game }) => {
     const { chess } = useChess();
     const api = useApi();
     const request = useRequest<Date>();
-    const [initialPgn, setInitialPgn] = useState(chess?.renderPgn() || '');
+    const initialPgnRef = useRef(chess?.renderPgn() || '');
+    const saveInFlightRef = useRef(false);
+    const pendingSaveRef = useRef<PendingSave>(undefined);
     const [hasChanges, setHasChanges] = useState(false);
     const [undoLog, setUndoLog] = useState<UndoLog[]>([]);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
@@ -57,26 +66,42 @@ const StatusIcon: React.FC<StatusIconProps> = ({ game }) => {
     const { updatedAtRef, setHasUnsavedGameChanges } = useGame();
     const reconcile = useReconcile();
 
-    const onSave = (cohort: string, id: string, pgnText: string, isUndo?: boolean) => {
-        if (pgnText !== initialPgn) {
-            request.onStart();
-            api.updateGame(cohort, id, {
-                type: GameImportTypes.editor,
-                pgnText,
-                updatedAt: updatedAtRef?.current,
-            })
-                .then((resp) => {
-                    trackEvent(EventType.UpdateGame, {
-                        method: 'autosave',
-                        dojo_cohort: cohort,
+    const processSaveQueue = async () => {
+        if (saveInFlightRef.current) {
+            return;
+        }
+
+        saveInFlightRef.current = true;
+        try {
+            while (pendingSaveRef.current) {
+                const pendingSave = pendingSaveRef.current;
+                pendingSaveRef.current = undefined;
+                const previousPgn = initialPgnRef.current;
+
+                if (pendingSave.pgnText === previousPgn) {
+                    setHasChanges(chess?.renderPgn() !== previousPgn);
+                    continue;
+                }
+
+                request.onStart();
+                try {
+                    const resp = await api.updateGame(pendingSave.cohort, pendingSave.id, {
+                        type: GameImportTypes.editor,
+                        pgnText: pendingSave.pgnText,
+                        updatedAt: updatedAtRef?.current,
                     });
 
-                    if (!isUndo) {
+                    trackEvent(EventType.UpdateGame, {
+                        method: 'autosave',
+                        dojo_cohort: pendingSave.cohort,
+                    });
+
+                    if (!pendingSave.isUndo) {
                         setUndoLog((log) => [
                             ...log,
                             {
                                 date: request.data || new Date(game.updatedAt || ''),
-                                pgn: initialPgn,
+                                pgn: previousPgn,
                             },
                         ]);
                     }
@@ -86,15 +111,21 @@ const StatusIcon: React.FC<StatusIconProps> = ({ game }) => {
                     }
                     const date = new Date();
                     request.onSuccess(date);
-                    setInitialPgn(pgnText);
-                    setHasChanges(false);
-                })
-                .catch((err) => {
+                    initialPgnRef.current = pendingSave.pgnText;
+                    setHasChanges(chess?.renderPgn() !== pendingSave.pgnText);
+                } catch (err) {
                     request.onFailure(err);
-                });
-        } else {
-            setHasChanges(false);
+                    return;
+                }
+            }
+        } finally {
+            saveInFlightRef.current = false;
         }
+    };
+
+    const onSave = (cohort: string, id: string, pgnText: string, isUndo?: boolean) => {
+        pendingSaveRef.current = { cohort, id, pgnText, isUndo };
+        void processSaveQueue();
     };
 
     const debouncedOnSave = useDebounce(onSave);
@@ -117,10 +148,10 @@ const StatusIcon: React.FC<StatusIconProps> = ({ game }) => {
                 handler: (event: Event) => {
                     if (event.type === ChessEventType.Initialized) {
                         const pgn = chess.renderPgn();
-                        setInitialPgn(pgn);
+                        initialPgnRef.current = pgn;
                     } else {
                         const pgn = chess.renderPgn();
-                        setHasChanges(pgn !== initialPgn);
+                        setHasChanges(pgn !== initialPgnRef.current);
                         debouncedOnSave(game.cohort, game.id, pgn);
                     }
                 },
@@ -129,7 +160,7 @@ const StatusIcon: React.FC<StatusIconProps> = ({ game }) => {
             chess.addObserver(observer);
             return () => chess.removeObserver(observer);
         }
-    }, [chess, game, initialPgn, setInitialPgn, debouncedOnSave, setHasChanges]);
+    }, [chess, game, debouncedOnSave, setHasChanges]);
 
     useEffect(() => {
         setHasUnsavedGameChanges?.(hasChanges);


### PR DESCRIPTION
## Summary

owned game autosaves could overlap when more changes were made while a save was still running. an older request could also finish and mark the game as saved even though the board had newer unsaved changes.

this serializes the autosaves and keeps only the latest pending PGN. queued saves wait for the current request to finish and use the updated `updatedAt` value returned by it.

the game is now only marked as saved when the live board still matches the PGN that was successfully saved.

## Related Issues

Closes #2605 
