### PR TITLE
Fix/analysis create error handling

### DIFF
--- a/frontend/src/hooks/useSaveGame.ts
+++ b/frontend/src/hooks/useSaveGame.ts
@@ -17,7 +17,7 @@ import { useSessionStorage } from 'usehooks-ts';
 const STAGED_CREATE_GAME_KEY = 'useSaveGame:stageCreateGame';
 
 export interface UseSaveGameFields {
-    createGame: (req: CreateGameRequest, onNavigate?: () => void) => Promise<void>;
+    createGame: (req: CreateGameRequest, onNavigate?: () => void) => Promise<boolean>;
     updateGame: (req: UpdateGameRequest) => Promise<Game | undefined>;
     setStagedGame: (req: CreateGameRequest) => void;
     stagedGame: CreateGameRequest | null;
@@ -46,8 +46,10 @@ export default function useSaveGame(): UseSaveGameFields {
                 request.onSuccess(`Created ${response.data.count} games`);
             }
             setStagedGame(null);
+            return true;
         } catch (err) {
             request.onFailure(err);
+            return false;
         }
     };
 

--- a/frontend/src/hooks/useUnsavedGame.test.tsx
+++ b/frontend/src/hooks/useUnsavedGame.test.tsx
@@ -1,0 +1,81 @@
+import { useApi } from '@/api/Api';
+import { useChess } from '@/board/pgn/PgnBoard';
+import useGame from '@/context/useGame';
+import { useRouter } from '@/hooks/useRouter';
+import { Chess } from '@jackstenglein/chess';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUnsavedGame } from './useUnsavedGame';
+
+vi.mock('@/analytics/events', () => ({
+    EventType: { SubmitGame: 'SubmitGame' },
+    trackEvent: vi.fn(),
+}));
+vi.mock('@/api/Api', () => ({ useApi: vi.fn() }));
+vi.mock('@/board/pgn/PgnBoard', () => ({ useChess: vi.fn() }));
+vi.mock('@/context/useGame', () => ({ default: vi.fn() }));
+vi.mock('@/hooks/useRouter', () => ({ useRouter: vi.fn() }));
+
+const form = {
+    white: 'White',
+    black: 'Black',
+    date: null,
+    result: '*',
+    orientation: 'white' as const,
+};
+
+describe('useUnsavedGame', () => {
+    const createGame = vi.fn();
+    const push = vi.fn();
+    const chess = {
+        setHeader: vi.fn(),
+        pgn: { render: vi.fn(() => '1. e4 e5 *') },
+    } as unknown as Chess;
+
+    beforeEach(() => {
+        sessionStorage.clear();
+        vi.mocked(useApi).mockReturnValue({ createGame } as unknown as ReturnType<typeof useApi>);
+        vi.mocked(useChess).mockReturnValue({ chess: undefined });
+        vi.mocked(useGame).mockReturnValue({});
+        vi.mocked(useRouter).mockReturnValue({ push } as unknown as ReturnType<typeof useRouter>);
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.clearAllMocks();
+    });
+
+    it('keeps the save dialog open when creating the game fails', async () => {
+        createGame.mockRejectedValue(new Error('Internal server error'));
+        const onNavigate = vi.fn();
+        const { result } = renderHook(() => useUnsavedGame(chess));
+
+        act(() => result.current.setShowDialog(true));
+
+        await act(async () => {
+            await result.current.onSubmit(form, onNavigate);
+        });
+
+        expect(result.current.showDialog).toBe(true);
+        expect(result.current.request.isFailure()).toBe(true);
+        expect(onNavigate).not.toHaveBeenCalled();
+    });
+
+    it('closes the save dialog and navigates after creating the game', async () => {
+        createGame.mockResolvedValue({
+            data: { id: 'game-id', cohort: '1500-1600' },
+        });
+        const onNavigate = vi.fn();
+        const { result } = renderHook(() => useUnsavedGame(chess));
+
+        act(() => result.current.setShowDialog(true));
+
+        await act(async () => {
+            await result.current.onSubmit(form, onNavigate);
+        });
+
+        expect(result.current.showDialog).toBe(false);
+        expect(result.current.request.isFailure()).toBe(false);
+        expect(onNavigate).toHaveBeenCalledOnce();
+    });
+});

--- a/frontend/src/hooks/useUnsavedGame.ts
+++ b/frontend/src/hooks/useUnsavedGame.ts
@@ -45,9 +45,10 @@ export function useUnsavedGame(chessProp?: Chess) {
             req.directory = undefined;
         }
 
-        await createGame(req, onNavigate).then(() => {
+        const success = await createGame(req, onNavigate);
+        if (success) {
             setShowDialog(false);
-        });
+        }
     };
 
     return {


### PR DESCRIPTION
## Summary

when saving an analysis, `createGame` was catching failed requests but still resolving normally. `useUnsavedGame` treated that as a successful save and closed the dialog, even though the game was not created.

`createGame` now reports whether the request succeeded, and the save dialog only closes after a successful create. if the request fails, the existing error is still shown and the dialog stays open so the user can retry without losing the dialog

## Related Issues

Closes #2612 

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}} 

