### PR TITLE
fix: bypass profile navigation guard after save

### DIFF
--- a/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.test.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.test.tsx
@@ -1,0 +1,213 @@
+import type { RatingEditor } from '@/components/profile/edit/RatingsEditor';
+import { RatingSystem, User } from '@/database/user';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProfileEditorPage } from './ProfileEditorPage';
+
+const mocks = vi.hoisted(() => ({
+    api: {
+        updateUser: vi.fn(),
+    },
+    guardEnabled: undefined as undefined | (() => boolean),
+    guardStatesAtPush: [] as boolean[],
+    routerPush: vi.fn(),
+    setLocaleCookie: vi.fn(),
+}));
+
+vi.mock('@/analytics/events', () => ({
+    EventType: { EditProfile: 'EditProfile' },
+    setUserProperties: vi.fn(),
+    trackEvent: vi.fn(),
+}));
+
+vi.mock('@/api/Api', () => ({
+    useApi: () => mocks.api,
+}));
+
+vi.mock('@/api/cache/Cache', () => ({
+    useCache: () => ({ setImageBypass: vi.fn() }),
+}));
+
+vi.mock('@/components/navigation/Link', () => ({
+    Link: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/profile/edit/NotificationSettingsEditor', () => ({
+    default: ({
+        notificationSettings,
+        setNotificationSettings,
+    }: {
+        notificationSettings: Record<string, unknown>;
+        setNotificationSettings: (settings: Record<string, unknown>) => void;
+    }) => (
+        <button
+            onClick={() =>
+                setNotificationSettings({
+                    ...notificationSettings,
+                    testNotification: true,
+                })
+            }
+        >
+            Change notifications
+        </button>
+    ),
+}));
+
+vi.mock('@/components/profile/edit/PersonalAccessTokensEditor', () => ({
+    PersonalAccessTokensEditor: () => null,
+}));
+
+vi.mock('@/components/profile/edit/PersonalInfoEditor', () => ({
+    PersonalInfoEditor: ({ setLanguage }: { setLanguage: (language: string) => void }) => (
+        <button onClick={() => setLanguage('de')}>Change language</button>
+    ),
+}));
+
+vi.mock('@/components/profile/edit/RatingsEditor', () => ({
+    RatingsEditor: ({
+        ratingEditors,
+        ratingSystem,
+        setRatingEditors,
+    }: {
+        ratingEditors: Record<RatingSystem, RatingEditor>;
+        ratingSystem: RatingSystem;
+        setRatingEditors: (ratingEditors: Record<RatingSystem, RatingEditor>) => void;
+    }) => (
+        <button
+            onClick={() =>
+                setRatingEditors({
+                    ...ratingEditors,
+                    [ratingSystem]: {
+                        ...ratingEditors[ratingSystem],
+                        currentRating: '1600',
+                    },
+                })
+            }
+        >
+            Change rating
+        </button>
+    ),
+}));
+
+vi.mock('@/components/profile/edit/ResetProgressButton', () => ({
+    ResetProgressButton: () => null,
+}));
+
+vi.mock('@/components/profile/edit/SubscriptionManager', () => ({
+    default: () => null,
+}));
+
+vi.mock('@/hooks/useRouter', () => ({
+    useRouter: () => ({ push: mocks.routerPush }),
+}));
+
+vi.mock('@/i18n/locales', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/i18n/locales')>();
+    return { ...actual, setLocaleCookie: mocks.setLocaleCookie };
+});
+
+vi.mock('next-intl', () => ({
+    useTranslations: () => {
+        const t = (key: string) => (key === 'save' ? 'Save' : key);
+        t.has = () => false;
+        return t;
+    },
+}));
+
+vi.mock('next-navigation-guard', () => ({
+    useNavigationGuard: ({ enabled }: { enabled: boolean | (() => boolean) }) => {
+        mocks.guardEnabled = typeof enabled === 'function' ? enabled : () => enabled;
+        return { active: false, accept: vi.fn(), reject: vi.fn() };
+    },
+}));
+
+const user = {
+    username: 'test-user',
+    displayName: 'Test User',
+    dojoCohort: '1500-1600',
+    ratingSystem: RatingSystem.Chesscom,
+    ratings: {
+        [RatingSystem.Chesscom]: {
+            username: 'test-user',
+            startRating: 1500,
+            currentRating: 1500,
+            hideUsername: false,
+        },
+    },
+    notificationSettings: {},
+} as User;
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.guardEnabled = undefined;
+    mocks.guardStatesAtPush = [];
+    mocks.api.updateUser.mockResolvedValue({});
+    mocks.routerPush.mockImplementation(() => {
+        mocks.guardStatesAtPush.push(mocks.guardEnabled?.() ?? false);
+    });
+});
+
+describe('ProfileEditorPage', () => {
+    const changeRatingAndSave = async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Change rating' }));
+
+        const saveButton = screen.getByTestId('save-ratings-button');
+        await waitFor(() => expect(saveButton).toBeEnabled());
+        fireEvent.click(saveButton);
+    };
+
+    it('navigates without triggering the guard after saving the only changed section', async () => {
+        render(<ProfileEditorPage user={user} />);
+
+        await changeRatingAndSave();
+
+        await waitFor(() => expect(mocks.routerPush).toHaveBeenCalledWith('/profile'));
+        expect(mocks.routerPush).toHaveBeenCalledTimes(1);
+        expect(mocks.guardStatesAtPush).toEqual([false]);
+    });
+
+    it('keeps the guard enabled when another section still has unsaved changes', async () => {
+        render(<ProfileEditorPage user={user} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Change notifications' }));
+        await changeRatingAndSave();
+
+        await waitFor(() => expect(screen.getByTestId('save-ratings-button')).toBeDisabled());
+        expect(mocks.routerPush).not.toHaveBeenCalled();
+        expect(mocks.guardEnabled?.()).toBe(true);
+    });
+
+    it('keeps the guard enabled when saving fails', async () => {
+        mocks.api.updateUser.mockRejectedValue(new Error('Update failed'));
+        render(<ProfileEditorPage user={user} />);
+
+        await changeRatingAndSave();
+
+        expect(await screen.findByText('Update failed')).toBeInTheDocument();
+        expect(mocks.routerPush).not.toHaveBeenCalled();
+        expect(mocks.guardEnabled?.()).toBe(true);
+    });
+
+    it('applies a saved language after the remaining changes are discarded', async () => {
+        render(<ProfileEditorPage user={user} />);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Change language' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Change notifications' }));
+
+        const savePersonalButton = screen.getByTestId('save-personal-button');
+        await waitFor(() => expect(savePersonalButton).toBeEnabled());
+        fireEvent.click(savePersonalButton);
+
+        await waitFor(() => expect(savePersonalButton).toBeDisabled());
+        expect(mocks.setLocaleCookie).not.toHaveBeenCalled();
+        expect(mocks.guardEnabled?.()).toBe(true);
+
+        fireEvent.click(screen.getByTestId('cancel-notifications-button'));
+
+        await waitFor(() => expect(mocks.setLocaleCookie).toHaveBeenCalledWith('de'));
+        expect(mocks.routerPush).not.toHaveBeenCalled();
+        expect(mocks.guardEnabled?.()).toBe(false);
+    });
+});

--- a/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
@@ -49,7 +49,7 @@ import {
 } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useNavigationGuard } from 'next-navigation-guard';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 export const MAX_PROFILE_PICTURE_SIZE_MB = 9;
 
@@ -159,6 +159,8 @@ export function ProfileEditorPage({ user }: { user: User }) {
     const t = useTranslations('profile.editor');
     const tRating = useTranslations('enums.ratingSystem');
 
+    const [savedUser, setSavedUser] = useState(user);
+
     const [displayName, setDisplayName] = useState(user.displayName || '');
     const [dojoCohort, setDojoCohort] = useState(
         user.dojoCohort !== 'NO_COHORT' ? user.dojoCohort : '',
@@ -180,20 +182,21 @@ export function ProfileEditorPage({ user }: { user: User }) {
     const [profilePictureData, setProfilePictureData] = useState<string>();
 
     const [errors, setErrors] = useState<Record<string, string>>({});
-    const [bypassGuard, setBypassGuard] = useState(false);
+    const postSaveNavigationRef = useRef<{ language?: string } | undefined>(undefined);
     const request = useRequest<string>();
 
     const personalUpdate = getUpdate(
-        user,
+        savedUser,
         {
             displayName: displayName.trim(),
-            bio: bio === '' && user.bio === undefined ? undefined : bio,
-            coachBio: coachBio === '' && user.coachBio === undefined ? undefined : coachBio,
+            bio: bio === '' && savedUser.bio === undefined ? undefined : bio,
+            coachBio: coachBio === '' && savedUser.coachBio === undefined ? undefined : coachBio,
             timezoneOverride:
-                timezone === DefaultTimezone && !user.timezoneOverride
-                    ? user.timezoneOverride
+                timezone === DefaultTimezone && !savedUser.timezoneOverride
+                    ? savedUser.timezoneOverride
                     : timezone,
-            language: language === DEFAULT_LOCALE && !user.language ? user.language : language,
+            language:
+                language === DEFAULT_LOCALE && !savedUser.language ? savedUser.language : language,
         },
         profilePictureData,
     );
@@ -201,16 +204,17 @@ export function ProfileEditorPage({ user }: { user: User }) {
     const personalChangesMade = Boolean(personalUpdate);
 
     const ratingsUpdate = getUpdate(
-        user,
+        savedUser,
         {
             dojoCohort: dojoCohort === '' ? 'NO_COHORT' : dojoCohort,
             ratingSystem,
             ratings:
-                JSON.stringify(ratingEditors) === JSON.stringify(getRatingEditors(user.ratings))
-                    ? user.ratings
+                JSON.stringify(ratingEditors) ===
+                JSON.stringify(getRatingEditors(savedUser.ratings))
+                    ? savedUser.ratings
                     : getRatingsFromEditors(ratingEditors),
             enableZenMode:
-                !enableZenMode && user.enableZenMode === undefined ? undefined : enableZenMode,
+                !enableZenMode && savedUser.enableZenMode === undefined ? undefined : enableZenMode,
         },
         undefined,
     );
@@ -218,12 +222,12 @@ export function ProfileEditorPage({ user }: { user: User }) {
     const ratingsChangesMade = Boolean(ratingsUpdate);
 
     const notificationsUpdate = getUpdate(
-        user,
+        savedUser,
         {
             notificationSettings:
                 JSON.stringify(notificationSettings) ===
-                JSON.stringify(user.notificationSettings || {})
-                    ? user.notificationSettings
+                JSON.stringify(savedUser.notificationSettings || {})
+                    ? savedUser.notificationSettings
                     : notificationSettings,
         },
         undefined,
@@ -231,8 +235,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
 
     const notificationsChangesMade = Boolean(notificationsUpdate);
 
-    const hasUnsavedChanges =
-        !bypassGuard && (personalChangesMade || ratingsChangesMade || notificationsChangesMade);
+    const hasUnsavedChanges = personalChangesMade || ratingsChangesMade || notificationsChangesMade;
 
     const navGuard = useNavigationGuard({
         enabled: hasUnsavedChanges,
@@ -250,6 +253,36 @@ export function ProfileEditorPage({ user }: { user: User }) {
         return () => window.removeEventListener('beforeunload', handleBeforeUnload);
     }, [hasUnsavedChanges]);
 
+    useEffect(() => {
+        const postSaveNavigation = postSaveNavigationRef.current;
+        if (!postSaveNavigation) {
+            return;
+        }
+
+        if (hasUnsavedChanges) {
+            if (!postSaveNavigation.language) {
+                postSaveNavigationRef.current = undefined;
+            }
+            return;
+        }
+
+        postSaveNavigationRef.current = undefined;
+        if (postSaveNavigation.language) {
+            setLocaleCookie(postSaveNavigation.language);
+            // Hard reload on language change so the server re-renders
+            // the tree with the new locale's messages bundle. Soft
+            // navigation leaves some client components holding on to
+            // the previous locale's messages (the language changes
+            // only after a second switch), so force a full fetch.
+            window.location.href =
+                postSaveNavigation.language === DEFAULT_LOCALE
+                    ? '/profile'
+                    : `/${postSaveNavigation.language}/profile`;
+        } else {
+            router.push('/profile');
+        }
+    }, [hasUnsavedChanges, router, savedUser]);
+
     const saveSection = (updatePayload: Partial<UserUpdate>) => {
         request.onStart();
         api.updateUser(updatePayload)
@@ -258,28 +291,18 @@ export function ProfileEditorPage({ user }: { user: User }) {
                 trackEvent(EventType.EditProfile, {
                     fields: Object.keys(updatePayload),
                 });
-                setUserProperties({ ...user, ...updatePayload });
+                const updatedUser = { ...savedUser, ...updatePayload };
+                setSavedUser(updatedUser);
+                setUserProperties(updatedUser);
 
                 if (updatePayload.profilePictureData !== undefined) {
                     setImageBypass(Date.now());
-                }
-                if (updatePayload.language) {
-                    setLocaleCookie(updatePayload.language);
-                    // Hard reload on language change so the server re-renders
-                    // the tree with the new locale's messages bundle. Soft
-                    // navigation leaves some client components holding on to
-                    // the previous locale's messages (the language changes
-                    // only after a second switch), so force a full fetch.
-                    window.location.href =
-                        updatePayload.language === DEFAULT_LOCALE
-                            ? '/profile'
-                            : `/${updatePayload.language}/profile`;
-                } else {
-                    router.push('/profile');
+                    setProfilePictureData(undefined);
                 }
 
-                setBypassGuard(true);
-                router.push('/profile');
+                postSaveNavigationRef.current = {
+                    language: updatePayload.language ?? postSaveNavigationRef.current?.language,
+                };
             })
             .catch((err) => {
                 request.onFailure(err);
@@ -300,10 +323,11 @@ export function ProfileEditorPage({ user }: { user: User }) {
     };
 
     const onCancelPersonal = () => {
-        setDisplayName(user.displayName || '');
-        setBio(user.bio || '');
-        setCoachBio(user.coachBio || '');
-        setTimezone(user.timezoneOverride || DefaultTimezone);
+        setDisplayName(savedUser.displayName || '');
+        setBio(savedUser.bio || '');
+        setCoachBio(savedUser.coachBio || '');
+        setTimezone(savedUser.timezoneOverride || DefaultTimezone);
+        setLanguage(savedUser.language || DEFAULT_LOCALE);
         setProfilePictureUrl(undefined);
         setProfilePictureData(undefined);
         setErrors({});
@@ -356,10 +380,10 @@ export function ProfileEditorPage({ user }: { user: User }) {
     };
 
     const onCancelRatings = () => {
-        setDojoCohort(user.dojoCohort !== 'NO_COHORT' ? user.dojoCohort : '');
-        setRatingSystem(user.ratingSystem);
-        setRatingEditors(getRatingEditors(user.ratings));
-        setEnableZenMode(user.enableZenMode || false);
+        setDojoCohort(savedUser.dojoCohort !== 'NO_COHORT' ? savedUser.dojoCohort : '');
+        setRatingSystem(savedUser.ratingSystem);
+        setRatingEditors(getRatingEditors(savedUser.ratings));
+        setEnableZenMode(savedUser.enableZenMode || false);
         setErrors({});
     };
 
@@ -372,7 +396,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
     };
 
     const onCancelNotifications = () => {
-        setNotificationSettings(user.notificationSettings || {});
+        setNotificationSettings(savedUser.notificationSettings || {});
         setErrors({});
     };
 
@@ -514,6 +538,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
                                 }}
                             >
                                 <Button
+                                    data-testid='save-personal-button'
                                     variant='contained'
                                     onClick={onSavePersonal}
                                     disabled={!personalChangesMade}
@@ -556,6 +581,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
                                 }}
                             >
                                 <Button
+                                    data-testid='save-ratings-button'
                                     variant='contained'
                                     onClick={onSaveRatings}
                                     disabled={!ratingsChangesMade}
@@ -601,6 +627,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
                                 </Button>
 
                                 <Button
+                                    data-testid='cancel-notifications-button'
                                     variant='contained'
                                     color='error'
                                     disableElevation

--- a/frontend/src/components/auth/RequireProfile.test.tsx
+++ b/frontend/src/components/auth/RequireProfile.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RequireProfile } from './RequireProfile';
+
+const mocks = vi.hoisted(() => ({
+    pathname: '/profile/edit',
+    locale: 'en',
+    router: {
+        push: vi.fn(),
+        replace: vi.fn(),
+    },
+    setLocaleCookie: vi.fn(),
+}));
+
+vi.mock('@/api/Api', () => ({
+    useApi: () => ({ checkUserAccess: vi.fn() }),
+}));
+
+vi.mock('@/api/Request', () => ({
+    useRequest: () => ({
+        isSent: () => true,
+        onStart: vi.fn(),
+        onSuccess: vi.fn(),
+        onFailure: vi.fn(),
+    }),
+}));
+
+vi.mock('@/auth/Auth', () => ({
+    AuthStatus: { Authenticated: 'Authenticated' },
+    useAuth: () => ({
+        status: 'Authenticated',
+        user: { language: 'de' },
+        updateUser: vi.fn(),
+    }),
+}));
+
+vi.mock('@/database/user', () => ({
+    hasCreatedProfile: () => true,
+}));
+
+vi.mock('@/i18n/locales', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/i18n/locales')>();
+    return { ...actual, setLocaleCookie: mocks.setLocaleCookie };
+});
+
+vi.mock('@/i18n/navigation', () => ({
+    usePathname: () => mocks.pathname,
+    useRouter: () => mocks.router,
+}));
+
+vi.mock('next-intl', () => ({
+    useLocale: () => mocks.locale,
+}));
+
+afterEach(cleanup);
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.pathname = '/profile/edit';
+    mocks.locale = 'en';
+});
+
+describe('RequireProfile language navigation', () => {
+    it('leaves language navigation to the profile editor while settings are being edited', () => {
+        render(<RequireProfile />);
+
+        expect(mocks.setLocaleCookie).not.toHaveBeenCalled();
+        expect(mocks.router.replace).not.toHaveBeenCalled();
+    });
+
+    it('still applies the preferred language outside the profile editor', async () => {
+        mocks.pathname = '/calendar';
+        render(<RequireProfile />);
+
+        await waitFor(() => expect(mocks.setLocaleCookie).toHaveBeenCalledWith('de'));
+        expect(mocks.router.replace).toHaveBeenCalledWith('/calendar', { locale: 'de' });
+    });
+});

--- a/frontend/src/components/auth/RequireProfile.tsx
+++ b/frontend/src/components/auth/RequireProfile.tsx
@@ -41,6 +41,9 @@ export function RequireProfile() {
     }, [request, api, status, updateUser, user]);
 
     useEffect(() => {
+        // ProfileEditorPage delays language navigation until every edited section is clean.
+        if (pathname === '/profile/edit') return;
+
         const preferred = user?.language;
         if (!preferred) return;
         // Persist the cross-device preference into the cookie so the


### PR DESCRIPTION
## Summary

updated profile saving so successfully saved sections are no longer treated as dirty. this prevents the unsaved changes dialog from appearing after a save and avoids duplicate navigation.
other edited sections stay unsaved and protected by the navigation guard. also adjusted `RequireProfile` so it doesnt try to sync the language while `/profile/edit` is handling unsaved changes.

## Related Issues

Closes #2658 
Related to #2312 

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)
*   [ ] New feature (non-breaking change which adds functionality)
*   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
*   [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests due to {{reason}} 
