### PR TITLE
feat(#2660): add training activity privacy controls

### DIFF
--- a/backend/clubService/get/main.go
+++ b/backend/clubService/get/main.go
@@ -9,7 +9,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository = database.DynamoDB
 var stage = os.Getenv("stage")
@@ -26,7 +29,10 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event api.Request) (api.Response, error) {
+func handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() {
+		response = trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).ProtectUsers(response)
+	}()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/clubService/processJoinRequest/main.go
+++ b/backend/clubService/processJoinRequest/main.go
@@ -10,7 +10,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository = database.DynamoDB
 
@@ -27,7 +30,10 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event api.Request) (api.Response, error) {
+func handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() {
+		response = trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).ProtectUsers(response)
+	}()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/clubService/serverless.yml
+++ b/backend/clubService/serverless.yml
@@ -81,7 +81,20 @@ functions:
       - httpApi:
           path: /public/clubs/{id}
           method: get
+      - httpApi:
+          path: /clubs/{id}
+          method: get
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:GetItem
@@ -146,6 +159,13 @@ functions:
             type: jwt
             id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:UpdateItem

--- a/backend/coach/list/main.go
+++ b/backend/coach/list/main.go
@@ -9,7 +9,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository = database.DynamoDB
 var coachesStr = os.Getenv("coaches")
@@ -18,7 +21,10 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event api.Request) (api.Response, error) {
+func handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() {
+		response = trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).ProtectUsers(response)
+	}()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/coach/serverless.yml
+++ b/backend/coach/serverless.yml
@@ -36,6 +36,13 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
+      - Effect: Allow
+        Action:
           - dynamodb:BatchGetItem
         Resource: ${param:UsersTableArn}
     environment:

--- a/backend/database/training_privacy.go
+++ b/backend/database/training_privacy.go
@@ -1,0 +1,62 @@
+package database
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
+)
+
+func (repo *dynamoRepository) GetTrainingPrivacyUser(username string) (*User, error) {
+	user := &User{}
+	err := repo.getItem(&dynamodb.GetItemInput{
+		TableName: aws.String(userTable), ConsistentRead: aws.Bool(true),
+		Key:                  map[string]*dynamodb.AttributeValue{"username": {S: aws.String(username)}},
+		ProjectionExpression: aws.String("username, trainingVisibility, isAdmin, subscriptionStatus"),
+	}, user)
+	return user, err
+}
+
+func (repo *dynamoRepository) GetTrainingPrivacyFollower(poster, follower string) (*FollowerEntry, error) {
+	entry := &FollowerEntry{}
+	err := repo.getItem(&dynamodb.GetItemInput{
+		TableName: aws.String(followersTable), ConsistentRead: aws.Bool(true),
+		Key: map[string]*dynamodb.AttributeValue{"poster": {S: aws.String(poster)}, "follower": {S: aws.String(follower)}},
+	}, entry)
+	var apiErr *errors.Error
+	if errors.As(err, &apiErr) && apiErr.Code == 404 {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return entry, nil
+}
+
+// GetTrainingPrivacyUsers reads current policy from the base table in DynamoDB-sized batches.
+func (repo *dynamoRepository) GetTrainingPrivacyUsers(usernames []string) ([]*User, error) {
+	users := make([]*User, 0, len(usernames))
+	for start := 0; start < len(usernames); start += 100 {
+		end := min(start+100, len(usernames))
+		keys := make([]map[string]*dynamodb.AttributeValue, 0, end-start)
+		for _, username := range usernames[start:end] {
+			keys = append(keys, map[string]*dynamodb.AttributeValue{"username": {S: aws.String(username)}})
+		}
+		result, err := repo.svc.BatchGetItem(&dynamodb.BatchGetItemInput{RequestItems: map[string]*dynamodb.KeysAndAttributes{
+			userTable: {Keys: keys, ConsistentRead: aws.Bool(true), ProjectionExpression: aws.String("username, trainingVisibility, isAdmin, subscriptionStatus")},
+		}})
+		if err != nil {
+			return nil, errors.Wrap(500, "Unable to check training visibility", "BatchGetItem failed", err)
+		}
+		// A throttled/partial policy response must not default omitted users to Public.
+		if len(result.UnprocessedKeys) != 0 {
+			return nil, errors.New(503, "Unable to check training visibility. Please try again.", "Unprocessed policy keys")
+		}
+		var batch []*User
+		if err := dynamodbattribute.UnmarshalListOfMaps(result.Responses[userTable], &batch); err != nil {
+			return nil, err
+		}
+		users = append(users, batch...)
+	}
+	return users, nil
+}

--- a/backend/database/user.go
+++ b/backend/database/user.go
@@ -172,7 +172,22 @@ type RatingHistory struct {
 	Rating int `dynamodbav:"rating" json:"rating"`
 }
 
+type TrainingVisibility string
+
+const (
+	TrainingVisibilityPublic  TrainingVisibility = "PUBLIC"
+	TrainingVisibilityMembers TrainingVisibility = "DOJO_MEMBERS"
+	TrainingVisibilityMutuals TrainingVisibility = "MUTUALS"
+	TrainingVisibilityPrivate TrainingVisibility = "PRIVATE"
+)
+
+func (v TrainingVisibility) Valid() bool {
+	return v == TrainingVisibilityPublic || v == TrainingVisibilityMembers || v == TrainingVisibilityMutuals || v == TrainingVisibilityPrivate
+}
+
 type User struct {
+	TrainingVisibility TrainingVisibility `dynamodbav:"trainingVisibility,omitempty" json:"trainingVisibility,omitempty"`
+
 	// The user's Cognito username. Uniquely identifies a user
 	Username string `dynamodbav:"username" json:"username"`
 
@@ -745,6 +760,8 @@ func (u *User) GetIsCalendarAdmin() bool {
 // Some fields from the User type are removed as they cannot be updated. Other fields
 // are ignored by the json encoder because they cannot be manually updated by the user.
 type UserUpdate struct {
+	TrainingVisibility *TrainingVisibility `dynamodbav:"trainingVisibility,omitempty" json:"trainingVisibility,omitempty"`
+
 	// The user's preferred display name on the site
 	DisplayName *string `dynamodbav:"displayName,omitempty" json:"displayName,omitempty"`
 

--- a/backend/graduation/list/main.go
+++ b/backend/graduation/list/main.go
@@ -10,9 +10,11 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
 
 type graduationListRepository interface {
+	trainingprivacy.Repository
 	database.GraduationLister
 	database.GameLister
 }
@@ -33,23 +35,30 @@ func byCohortHandler(event api.Request) (api.Response, error) {
 		return api.Failure(err), nil
 	}
 
-	return api.Success(&ListGraduationsResponse{
+	graduations, err = trainingprivacy.Filter(trainingprivacy.New(repository, api.GetUserInfo(event).Username), graduations, func(g database.Graduation) string { return g.Username })
+	if err != nil {
+		return api.Failure(err), nil
+	}
+	return trainingprivacy.NoStore(api.Success(&ListGraduationsResponse{
 		Graduations:      graduations,
 		LastEvaluatedKey: lastKey,
-	}), nil
+	})), nil
 }
 
 func byOwnerHandler(event api.Request) (api.Response, error) {
+	if err := trainingprivacy.New(repository, api.GetUserInfo(event).Username).Require(event.PathParameters["username"]); err != nil {
+		return trainingprivacy.NoStore(api.Failure(err)), nil
+	}
 	username := event.PathParameters["username"]
 	startKey := event.QueryStringParameters["startKey"]
 	graduations, lastKey, err := repository.ListGraduationsByOwner(username, startKey)
 	if err != nil {
 		return api.Failure(err), nil
 	}
-	return api.Success(&ListGraduationsResponse{
+	return trainingprivacy.NoStore(api.Success(&ListGraduationsResponse{
 		Graduations:      graduations,
 		LastEvaluatedKey: lastKey,
-	}), nil
+	})), nil
 }
 
 func byDateHandler(event api.Request) (api.Response, error) {
@@ -60,14 +69,18 @@ func byDateHandler(event api.Request) (api.Response, error) {
 		return api.Failure(err), nil
 	}
 
+	graduations, err = trainingprivacy.Filter(trainingprivacy.New(repository, api.GetUserInfo(event).Username), graduations, func(g database.Graduation) string { return g.Username })
+	if err != nil {
+		return api.Failure(err), nil
+	}
 	if err := addRecentGamesAnnotated(graduations); err != nil {
 		return api.Failure(err), nil
 	}
 
-	return api.Success(&ListGraduationsResponse{
+	return trainingprivacy.NoStore(api.Success(&ListGraduationsResponse{
 		Graduations:      graduations,
 		LastEvaluatedKey: lastKey,
-	}), nil
+	})), nil
 }
 
 func addRecentGamesAnnotated(graduations []database.Graduation) error {

--- a/backend/graduation/list/main_test.go
+++ b/backend/graduation/list/main_test.go
@@ -209,3 +209,24 @@ func TestByCohortAndByOwnerHandlersKeepStoredGamesAnnotated(t *testing.T) {
 		t.Fatalf("non-date handlers should not query games, got calls: %#v", fake.gameCalls)
 	}
 }
+
+func (r *listGraduationsFakeRepo) GetTrainingPrivacyUser(username string) (*database.User, error) {
+	return &database.User{Username: username}, nil
+}
+func (r *listGraduationsFakeRepo) GetTrainingPrivacyFollower(poster, follower string) (*database.FollowerEntry, error) {
+	return nil, nil
+}
+
+func (r *listGraduationsFakeRepo) GetTrainingPrivacyUsers(names []string) ([]*database.User, error) {
+	result := make([]*database.User, 0, len(names))
+	for _, name := range names {
+		user, err := r.GetTrainingPrivacyUser(name)
+		if err != nil {
+			return nil, err
+		}
+		if user != nil {
+			result = append(result, user)
+		}
+	}
+	return result, nil
+}

--- a/backend/graduation/serverless.yml
+++ b/backend/graduation/serverless.yml
@@ -42,6 +42,13 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
+      - Effect: Allow
+        Action:
           - dynamodb:Query
         Resource:
           - Fn::Join:
@@ -64,6 +71,13 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
+      - Effect: Allow
+        Action:
           - dynamodb:Query
         Resource: ${param:GraduationsTableArn}
 
@@ -80,6 +94,13 @@ functions:
           path: /public/graduations
           method: get
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:Query

--- a/backend/newsfeed/comment/create/main.go
+++ b/backend/newsfeed/comment/create/main.go
@@ -12,11 +12,18 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository database.TimelineCommenter = database.DynamoDB
 
-func Handler(ctx context.Context, event api.Request) (api.Response, error) {
+func Handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() { response = trainingprivacy.NoStore(response) }()
+	if err := trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).Require(event.PathParameters["owner"]); err != nil {
+		return api.Failure(err), nil
+	}
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/newsfeed/comment/create/privacy_test.go
+++ b/backend/newsfeed/comment/create/privacy_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"testing"
+)
+
+type privateRepository struct{}
+
+func (privateRepository) GetTrainingPrivacyUser(name string) (*database.User, error) {
+	return &database.User{Username: name, TrainingVisibility: database.TrainingVisibilityPrivate}, nil
+}
+func (privateRepository) GetTrainingPrivacyFollower(string, string) (*database.FollowerEntry, error) {
+	return nil, nil
+}
+func TestPrivateActivityDeniedBeforeDataAccess(t *testing.T) {
+	oldPrivacy, oldRepo := privacyRepository, repository
+	defer func() { privacyRepository, repository = oldPrivacy, oldRepo }()
+	privacyRepository = privateRepository{}
+	repository = nil
+	response, err := Handler(context.Background(), api.Request{PathParameters: map[string]string{"owner": "someone", "id": "old-entry", "year": "2024"}, Body: `{"content":"test"}`})
+	if err != nil || response.StatusCode != 403 {
+		t.Fatalf("got %+v, %v", response, err)
+	}
+	if response.Headers["Cache-Control"] != "private, no-store" {
+		t.Fatal("missing cache control")
+	}
+}
+
+func (r privateRepository) GetTrainingPrivacyUsers(names []string) ([]*database.User, error) {
+	result := make([]*database.User, 0, len(names))
+	for _, name := range names {
+		user, err := r.GetTrainingPrivacyUser(name)
+		if err != nil {
+			return nil, err
+		}
+		if user != nil {
+			result = append(result, user)
+		}
+	}
+	return result, nil
+}

--- a/backend/newsfeed/get/main.go
+++ b/backend/newsfeed/get/main.go
@@ -8,7 +8,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository database.TimelineGetter = database.DynamoDB
 
@@ -16,7 +19,11 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event api.Request) (api.Response, error) {
+func handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() { response = trainingprivacy.NoStore(response) }()
+	if err := trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).Require(event.PathParameters["owner"]); err != nil {
+		return api.Failure(err), nil
+	}
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/newsfeed/get/privacy_test.go
+++ b/backend/newsfeed/get/privacy_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"testing"
+)
+
+type privateRepository struct{}
+
+func (privateRepository) GetTrainingPrivacyUser(name string) (*database.User, error) {
+	return &database.User{Username: name, TrainingVisibility: database.TrainingVisibilityPrivate}, nil
+}
+func (privateRepository) GetTrainingPrivacyFollower(string, string) (*database.FollowerEntry, error) {
+	return nil, nil
+}
+func TestPrivateActivityDeniedBeforeDataAccess(t *testing.T) {
+	oldPrivacy, oldRepo := privacyRepository, repository
+	defer func() { privacyRepository, repository = oldPrivacy, oldRepo }()
+	privacyRepository = privateRepository{}
+	repository = nil
+	response, err := handler(context.Background(), api.Request{PathParameters: map[string]string{"owner": "someone", "id": "old-entry", "year": "2024"}, Body: `{"content":"test"}`})
+	if err != nil || response.StatusCode != 403 {
+		t.Fatalf("got %+v, %v", response, err)
+	}
+	if response.Headers["Cache-Control"] != "private, no-store" {
+		t.Fatal("missing cache control")
+	}
+}
+
+func (r privateRepository) GetTrainingPrivacyUsers(names []string) ([]*database.User, error) {
+	result := make([]*database.User, 0, len(names))
+	for _, name := range names {
+		user, err := r.GetTrainingPrivacyUser(name)
+		if err != nil {
+			return nil, err
+		}
+		if user != nil {
+			result = append(result, user)
+		}
+	}
+	return result, nil
+}

--- a/backend/newsfeed/list/main.go
+++ b/backend/newsfeed/list/main.go
@@ -14,9 +14,12 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
 
 const limit = 25
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository = database.DynamoDB
 var stage = os.Getenv("stage")
@@ -34,7 +37,8 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event api.Request) (api.Response, error) {
+func handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() { response = trainingprivacy.NoStore(response) }()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 
@@ -83,6 +87,11 @@ func handler(ctx context.Context, event api.Request) (api.Response, error) {
 
 	log.Debugf("Fetching timeline entries: %#v", timelineEntries)
 	resultEntries, err := repository.BatchGetTimelineEntries(timelineEntries)
+	if err != nil {
+		return api.Failure(err), nil
+	}
+
+	resultEntries, err = trainingprivacy.Filter(trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username), resultEntries, func(e database.TimelineEntry) string { return e.Owner })
 	if err != nil {
 		return api.Failure(err), nil
 	}

--- a/backend/newsfeed/react/main.go
+++ b/backend/newsfeed/react/main.go
@@ -10,11 +10,18 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository database.TimelineReactor = database.DynamoDB
 
-func Handler(ctx context.Context, event api.Request) (api.Response, error) {
+func Handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() { response = trainingprivacy.NoStore(response) }()
+	if err := trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).Require(event.PathParameters["owner"]); err != nil {
+		return api.Failure(err), nil
+	}
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/newsfeed/react/privacy_test.go
+++ b/backend/newsfeed/react/privacy_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"testing"
+)
+
+type privateRepository struct{}
+
+func (privateRepository) GetTrainingPrivacyUser(name string) (*database.User, error) {
+	return &database.User{Username: name, TrainingVisibility: database.TrainingVisibilityPrivate}, nil
+}
+func (privateRepository) GetTrainingPrivacyFollower(string, string) (*database.FollowerEntry, error) {
+	return nil, nil
+}
+func TestPrivateActivityDeniedBeforeDataAccess(t *testing.T) {
+	oldPrivacy, oldRepo := privacyRepository, repository
+	defer func() { privacyRepository, repository = oldPrivacy, oldRepo }()
+	privacyRepository = privateRepository{}
+	repository = nil
+	response, err := Handler(context.Background(), api.Request{PathParameters: map[string]string{"owner": "someone", "id": "old-entry", "year": "2024"}, Body: `{"content":"test"}`})
+	if err != nil || response.StatusCode != 403 {
+		t.Fatalf("got %+v, %v", response, err)
+	}
+	if response.Headers["Cache-Control"] != "private, no-store" {
+		t.Fatal("missing cache control")
+	}
+}
+
+func (r privateRepository) GetTrainingPrivacyUsers(names []string) ([]*database.User, error) {
+	result := make([]*database.User, 0, len(names))
+	for _, name := range names {
+		user, err := r.GetTrainingPrivacyUser(name)
+		if err != nil {
+			return nil, err
+		}
+		if user != nil {
+			result = append(result, user)
+		}
+	}
+	return result, nil
+}

--- a/backend/newsfeed/serverless.yml
+++ b/backend/newsfeed/serverless.yml
@@ -112,7 +112,20 @@ functions:
       - httpApi:
           path: /public/newsfeed/{owner}/{id}
           method: get
+      - httpApi:
+          path: /newsfeed/{owner}/{id}
+          method: get
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:GetItem
@@ -128,6 +141,13 @@ functions:
             type: jwt
             id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:Query
@@ -155,6 +175,13 @@ functions:
       - Effect: Allow
         Action:
           - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
         Resource: ${param:UsersTableArn}
       - Effect: Allow
         Action:
@@ -177,6 +204,13 @@ functions:
             type: jwt
             id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:GetItem

--- a/backend/scoreboard/get/main.go
+++ b/backend/scoreboard/get/main.go
@@ -10,12 +10,15 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
 
 const (
 	requestType_Dojo      = "dojo"
 	requestType_Following = "following"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository database.ScoreboardSummaryLister = database.DynamoDB
 var stage = os.Getenv("stage")
@@ -32,7 +35,10 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event api.Request) (api.Response, error) {
+func handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() {
+		response = trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).ProtectUsers(response)
+	}()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/scoreboard/serverless.yml
+++ b/backend/scoreboard/serverless.yml
@@ -39,6 +39,13 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
+      - Effect: Allow
+        Action:
           - dynamodb:BatchGetItem
         Resource: ${param:UsersTableArn}
       - Effect: Allow

--- a/backend/serverless-compose.yml
+++ b/backend/serverless-compose.yml
@@ -41,6 +41,7 @@ services:
   coach:
     path: coach
     params:
+      FollowersTableArn: ${chess-dojo-scheduler.FollowersTableArn}
       httpApiId: ${chess-dojo-scheduler.HttpApiId}
       UsersTableArn: ${chess-dojo-scheduler.UsersTableArn}
 
@@ -68,6 +69,7 @@ services:
       GraduationsTableArn: ${chess-dojo-scheduler.GraduationsTableArn}
       UsersTableArn: ${chess-dojo-scheduler.UsersTableArn}
       GamesTableArn: ${chess-dojo-scheduler.GamesTableArn}
+      FollowersTableArn: ${chess-dojo-scheduler.FollowersTableArn}
 
   courseService:
     path: courseService
@@ -156,6 +158,9 @@ services:
     path: yearReviewService
     params:
       httpApiId: ${chess-dojo-scheduler.HttpApiId}
+      UsersTableArn: ${chess-dojo-scheduler.UsersTableArn}
+      FollowersTableArn: ${chess-dojo-scheduler.FollowersTableArn}
+      apiAuthorizer: ${chess-dojo-scheduler.serviceAuthorizer}
 
   clubService:
     path: clubService
@@ -166,6 +171,7 @@ services:
       PicturesBucket: ${chess-dojo-scheduler.PicturesBucket}
       NotificationEventQueueArn: ${notificationService.NotificationEventQueueArn}
       NotificationEventQueueUrl: ${notificationService.NotificationEventQueueUrl}
+      FollowersTableArn: ${chess-dojo-scheduler.FollowersTableArn}
 
   examService:
     path: examService

--- a/backend/trainingprivacy/privacy.go
+++ b/backend/trainingprivacy/privacy.go
@@ -1,0 +1,248 @@
+// Package trainingprivacy enforces the audience for training data at API boundaries.
+package trainingprivacy
+
+import (
+	"encoding/json"
+
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+)
+
+type Repository interface {
+	GetTrainingPrivacyUser(string) (*database.User, error)
+	GetTrainingPrivacyUsers([]string) ([]*database.User, error)
+	GetTrainingPrivacyFollower(string, string) (*database.FollowerEntry, error)
+}
+
+type Access struct {
+	repo    Repository
+	viewer  string
+	users   map[string]*database.User
+	allowed map[string]bool
+}
+
+func New(repo Repository, viewer string) *Access {
+	return &Access{repo: repo, viewer: viewer, users: map[string]*database.User{}, allowed: map[string]bool{}}
+}
+
+func (a *Access) user(username string) (*database.User, error) {
+	if u, ok := a.users[username]; ok {
+		return u, nil
+	}
+	u, err := a.repo.GetTrainingPrivacyUser(username)
+	if err != nil {
+		return nil, err
+	}
+	a.users[username] = u
+	return u, nil
+}
+
+func (a *Access) CanView(owner string) (bool, error) {
+	if owner != "" && owner == a.viewer {
+		return true, nil
+	}
+	if allowed, ok := a.allowed[owner]; ok {
+		return allowed, nil
+	}
+	allowed, err := a.canView(owner)
+	if err == nil {
+		a.allowed[owner] = allowed
+	}
+	return allowed, err
+}
+
+func (a *Access) canView(owner string) (bool, error) {
+	u, err := a.user(owner)
+	var apiErr *errors.Error
+	if errors.As(err, &apiErr) && apiErr.Code == 404 {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if u == nil {
+		return false, nil
+	}
+	if u.TrainingVisibility == "" || u.TrainingVisibility == database.TrainingVisibilityPublic {
+		return true, nil
+	}
+	if a.viewer == "" {
+		return false, nil
+	}
+	viewer, err := a.user(a.viewer)
+	if err != nil {
+		return false, err
+	}
+	if viewer == nil {
+		return false, nil
+	}
+	if viewer.IsAdmin {
+		return true, nil
+	}
+	switch u.TrainingVisibility {
+	case database.TrainingVisibilityMembers:
+		return viewer.IsSubscribed(), nil
+	case database.TrainingVisibilityMutuals:
+		forward, err := a.repo.GetTrainingPrivacyFollower(owner, a.viewer)
+		if err != nil || forward == nil {
+			return false, err
+		}
+		reverse, err := a.repo.GetTrainingPrivacyFollower(a.viewer, owner)
+		return reverse != nil, err
+	default:
+		return false, nil
+	}
+}
+
+func (a *Access) Require(owner string) error {
+	if owner == "" {
+		return errors.New(400, "Owner is required", "")
+	}
+	allowed, err := a.CanView(owner)
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return errors.New(403, "Training activity is private", "")
+	}
+	return nil
+}
+
+// NoStore prevents a response for one audience being reused for another.
+func NoStore(response api.Response) api.Response {
+	if response.Headers == nil {
+		response.Headers = map[string]string{}
+	}
+	response.Headers["Cache-Control"] = "private, no-store"
+	return response
+}
+
+// Training fields are omitted at the serialization boundary, never zeroed on stored users.
+var trainingFields = []string{
+	"progress", "customTasks", "pinnedTasks", "openingProgress", "minutesSpent", "totalDojoScore",
+	"numberOfGraduations", "previousCohort", "graduationCohorts", "lastGraduatedAt", "gamesCreated",
+	"workGoal", "workGoalHistory", "weeklyPlan", "gameSchedule", "timerSeconds", "timerStartedAt", "timerTaskId",
+	"exams", "puzzles", "squareColorRating", "mateInOneRating", "timeManagementRating", "sentMilestoneNotifications",
+}
+
+func (a *Access) redactUser(user map[string]any) error {
+	owner, ok := user["username"].(string)
+	if !ok || owner == "" {
+		return nil
+	}
+	allowed, err := a.CanView(owner)
+	if err != nil {
+		return err
+	}
+	user["canViewTraining"] = allowed
+	if !allowed {
+		for _, field := range trainingFields {
+			delete(user, field)
+		}
+	}
+	return nil
+}
+
+// ProtectUsers handles the existing user, cohort, scoreboard and club response envelopes.
+func (a *Access) ProtectUsers(response api.Response) api.Response {
+	if response.StatusCode != 200 {
+		return NoStore(response)
+	}
+	var payload any
+	if err := json.Unmarshal([]byte(response.Body), &payload); err != nil {
+		return NoStore(api.Failure(err))
+	}
+
+	var users []map[string]any
+	appendRows := func(rows []any) {
+		for _, row := range rows {
+			if user, ok := row.(map[string]any); ok {
+				users = append(users, user)
+			}
+		}
+	}
+	switch body := payload.(type) {
+	case []any:
+		appendRows(body)
+	case map[string]any:
+		if _, ok := body["username"]; ok {
+			users = append(users, body)
+		}
+		for _, key := range []string{"users", "data", "scoreboard"} {
+			if rows, ok := body[key].([]any); ok {
+				appendRows(rows)
+			}
+		}
+	}
+	owners := make([]string, 0, len(users))
+	for _, user := range users {
+		if owner, ok := user["username"].(string); ok {
+			owners = append(owners, owner)
+		}
+	}
+	if err := a.prime(owners); err != nil {
+		return NoStore(api.Failure(err))
+	}
+	for _, user := range users {
+		if err := a.redactUser(user); err != nil {
+			return NoStore(api.Failure(err))
+		}
+	}
+	return NoStore(api.Success(payload))
+}
+
+func (a *Access) prime(owners []string) error {
+	pending := map[string]bool{}
+	for _, owner := range owners {
+		if owner != "" && owner != a.viewer {
+			if _, ok := a.users[owner]; !ok {
+				pending[owner] = true
+			}
+		}
+	}
+	if len(pending) == 0 {
+		return nil
+	}
+	if a.viewer != "" {
+		if _, ok := a.users[a.viewer]; !ok {
+			pending[a.viewer] = true
+		}
+	}
+	names := make([]string, 0, len(pending))
+	for name := range pending {
+		names = append(names, name)
+	}
+	users, err := a.repo.GetTrainingPrivacyUsers(names)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		a.users[name] = nil
+	}
+	for _, user := range users {
+		a.users[user.Username] = user
+	}
+	return nil
+}
+
+func Filter[T any](a *Access, rows []T, owner func(T) string) ([]T, error) {
+	owners := make([]string, 0, len(rows))
+	for _, row := range rows {
+		owners = append(owners, owner(row))
+	}
+	if err := a.prime(owners); err != nil {
+		return nil, err
+	}
+	result := make([]T, 0, len(rows))
+	for _, row := range rows {
+		allowed, err := a.CanView(owner(row))
+		if err != nil {
+			return nil, err
+		}
+		if allowed {
+			result = append(result, row)
+		}
+	}
+	return result, nil
+}

--- a/backend/trainingprivacy/privacy_test.go
+++ b/backend/trainingprivacy/privacy_test.go
@@ -1,0 +1,187 @@
+package trainingprivacy
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+)
+
+type fakeRepository struct {
+	users   map[string]*database.User
+	follows map[string]bool
+	fail    bool
+}
+
+func (r *fakeRepository) GetTrainingPrivacyUser(name string) (*database.User, error) {
+	if r.fail {
+		return nil, fmt.Errorf("lookup failed")
+	}
+	return r.users[name], nil
+}
+func (r *fakeRepository) GetTrainingPrivacyFollower(poster, follower string) (*database.FollowerEntry, error) {
+	if r.fail {
+		return nil, fmt.Errorf("lookup failed")
+	}
+	if r.follows[poster+"/"+follower] {
+		return &database.FollowerEntry{}, nil
+	}
+	return nil, nil
+}
+func fixture() *fakeRepository {
+	return &fakeRepository{users: map[string]*database.User{
+		"owner":      {Username: "owner"},
+		"free":       {Username: "free"},
+		"subscriber": {Username: "subscriber", SubscriptionStatus: database.SubscriptionStatus_Subscribed},
+		"mutual":     {Username: "mutual"},
+		"oneway":     {Username: "oneway"},
+		"admin":      {Username: "admin", IsAdmin: true},
+		"coach":      {Username: "coach", IsCoach: true},
+	}, follows: map[string]bool{"owner/mutual": true, "mutual/owner": true, "owner/oneway": true}}
+}
+
+func TestAudienceMatrix(t *testing.T) {
+	for _, visibility := range []database.TrainingVisibility{"", database.TrainingVisibilityPublic, database.TrainingVisibilityMembers, database.TrainingVisibilityMutuals, database.TrainingVisibilityPrivate, "INVALID"} {
+		for _, viewer := range []string{"", "owner", "free", "subscriber", "oneway", "mutual", "admin", "coach"} {
+			t.Run(string(visibility)+"/"+viewer, func(t *testing.T) {
+				r := fixture()
+				r.users["owner"].TrainingVisibility = visibility
+				want := visibility == "" || visibility == database.TrainingVisibilityPublic || viewer == "owner" || viewer == "admin" || (visibility == database.TrainingVisibilityMembers && viewer == "subscriber") || (visibility == database.TrainingVisibilityMutuals && viewer == "mutual")
+				got, err := New(r, viewer).CanView("owner")
+				if err != nil || got != want {
+					t.Fatalf("got %v, %v; want %v", got, err, want)
+				}
+			})
+		}
+	}
+}
+
+func TestCurrentPolicyAndRelationships(t *testing.T) {
+	r := fixture()
+	check := func(viewer string, want bool) {
+		t.Helper()
+		got, err := New(r, viewer).CanView("owner")
+		if err != nil || got != want {
+			t.Fatalf("got %v, %v; want %v", got, err, want)
+		}
+	}
+	check("free", true)
+	r.users["owner"].TrainingVisibility = database.TrainingVisibilityPrivate
+	check("free", false)
+	r.users["owner"].TrainingVisibility = database.TrainingVisibilityPublic
+	check("free", true)
+	r.users["owner"].TrainingVisibility = database.TrainingVisibilityMutuals
+	check("mutual", true)
+	delete(r.follows, "owner/mutual")
+	check("mutual", false)
+	r.follows["owner/mutual"] = true
+	delete(r.follows, "mutual/owner")
+	check("mutual", false)
+	r.users["owner"].TrainingVisibility = database.TrainingVisibilityMembers
+	check("subscriber", true)
+	r.users["subscriber"].SubscriptionStatus = database.SubscriptionStatus_Canceled
+	check("subscriber", false)
+}
+
+func TestRedactionRetainsIdentityAndRemovesTraining(t *testing.T) {
+	for _, envelope := range []string{"", "users", "data", "scoreboard"} {
+		t.Run(envelope, func(t *testing.T) {
+			r := fixture()
+			r.users["owner"].TrainingVisibility = database.TrainingVisibilityPrivate
+			row := map[string]any{"username": "owner", "displayName": "Visible name", "dojoCohort": "1200-1300", "ratings": map[string]any{"FIDE": 1234}}
+			for _, field := range trainingFields {
+				row[field] = "SECRET"
+			}
+			var payload any = row
+			if envelope != "" {
+				payload = map[string]any{envelope: []any{row}, "lastEvaluatedKey": "next"}
+			}
+			resp := New(r, "free").ProtectUsers(api.Success(payload))
+			if resp.StatusCode != 200 || resp.Headers["Cache-Control"] != "private, no-store" {
+				t.Fatalf("bad response: %+v", resp)
+			}
+			var body map[string]any
+			_ = json.Unmarshal([]byte(resp.Body), &body)
+			if envelope != "" {
+				if body["lastEvaluatedKey"] != "next" {
+					t.Fatal("lost cursor")
+				}
+				body = body[envelope].([]any)[0].(map[string]any)
+			}
+			if body["displayName"] != "Visible name" || body["canViewTraining"] != false || body["ratings"] == nil {
+				t.Fatal("lost basic information or access flag")
+			}
+			for _, field := range trainingFields {
+				if _, ok := body[field]; ok {
+					t.Errorf("leaked %s", field)
+				}
+			}
+			if row["progress"] != "SECRET" {
+				t.Fatal("mutated original object")
+			}
+		})
+	}
+}
+
+func TestHistoricalEntriesAndFailures(t *testing.T) {
+	r := fixture()
+	r.users["owner"].TrainingVisibility = database.TrainingVisibilityPrivate
+	entries := []database.TimelineEntry{{TimelineEntryKey: database.TimelineEntryKey{Owner: "owner"}}}
+	visible, err := Filter(New(r, "free"), entries, func(e database.TimelineEntry) string { return e.Owner })
+	if err != nil || len(visible) != 0 {
+		t.Fatal("private historical entry exposed")
+	}
+	if err := New(r, "free").Require("owner"); err == nil {
+		t.Fatal("detail access allowed")
+	}
+	r.fail = true
+	if _, err := New(r, "free").CanView("owner"); err == nil {
+		t.Fatal("lookup failure allowed access")
+	}
+	resp := New(r, "free").ProtectUsers(api.Success(map[string]any{"username": "owner", "progress": "secret"}))
+	if resp.StatusCode == 200 {
+		t.Fatal("lookup failure returned user data")
+	}
+}
+
+func TestMissingPolicyNeverDefaultsToPublic(t *testing.T) {
+	r := fixture()
+	delete(r.users, "owner")
+	resp := New(r, "free").ProtectUsers(api.Success([]any{map[string]any{"username": "owner", "progress": "secret"}}))
+	var rows []map[string]any
+	if err := json.Unmarshal([]byte(resp.Body), &rows); err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0]["canViewTraining"] != false || rows[0]["progress"] != nil {
+		t.Fatal("missing policy exposed data")
+	}
+}
+
+func TestVisibilityValidation(t *testing.T) {
+	for _, value := range []database.TrainingVisibility{database.TrainingVisibilityPublic, database.TrainingVisibilityMembers, database.TrainingVisibilityMutuals, database.TrainingVisibilityPrivate} {
+		if !value.Valid() {
+			t.Errorf("rejected %s", value)
+		}
+	}
+	for _, value := range []database.TrainingVisibility{"", "public", "FRIENDS"} {
+		if value.Valid() {
+			t.Errorf("accepted %s", value)
+		}
+	}
+}
+
+func (r *fakeRepository) GetTrainingPrivacyUsers(names []string) ([]*database.User, error) {
+	result := make([]*database.User, 0, len(names))
+	for _, name := range names {
+		user, err := r.GetTrainingPrivacyUser(name)
+		if err != nil {
+			return nil, err
+		}
+		if user != nil {
+			result = append(result, user)
+		}
+	}
+	return result, nil
+}

--- a/backend/user/get/discord/main.go
+++ b/backend/user/get/discord/main.go
@@ -9,7 +9,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository = database.DynamoDB
 
@@ -17,7 +20,10 @@ func main() {
 	lambda.Start(Handler)
 }
 
-func Handler(ctx context.Context, event api.Request) (api.Response, error) {
+func Handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() {
+		response = trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).ProtectUsers(response)
+	}()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/user/get/main.go
+++ b/backend/user/get/main.go
@@ -9,7 +9,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository = database.DynamoDB
 
@@ -17,7 +20,10 @@ func main() {
 	lambda.Start(Handler)
 }
 
-func Handler(ctx context.Context, event api.Request) (api.Response, error) {
+func Handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() {
+		response = trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).ProtectUsers(response)
+	}()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/user/list/main.go
+++ b/backend/user/list/main.go
@@ -9,7 +9,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository database.UserLister = database.DynamoDB
 
@@ -18,7 +21,10 @@ type ListUsersResponse struct {
 	LastEvaluatedKey string           `json:"lastEvaluatedKey,omitempty"`
 }
 
-func Handler(ctx context.Context, event api.Request) (api.Response, error) {
+func Handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() {
+		response = trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).ProtectUsers(response)
+	}()
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/user/serverless.yml
+++ b/backend/user/serverless.yml
@@ -256,7 +256,20 @@ functions:
       - httpApi:
           path: /public/user/{username}
           method: get
+      - httpApi:
+          path: /user/profile/{username}
+          method: get
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:GetItem
@@ -336,6 +349,13 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
+      - Effect: Allow
+        Action:
           - dynamodb:Query
         Resource:
           - Fn::Join:
@@ -370,6 +390,13 @@ functions:
     iamRoleStatements:
       - Effect: Allow
         Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
+      - Effect: Allow
+        Action:
           - dynamodb:Query
         Resource: ${param:TimelineTableArn}
 
@@ -383,6 +410,13 @@ functions:
             type: jwt
             id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:Query

--- a/backend/user/timeline/list/main.go
+++ b/backend/user/timeline/list/main.go
@@ -8,7 +8,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository database.TimelineLister = database.DynamoDB
 
@@ -17,7 +20,11 @@ type ListTimelineEntriesResponse struct {
 	LastEvaluatedKey string                    `json:"lastEvaluatedKey,omitempty"`
 }
 
-func Handler(ctx context.Context, event api.Request) (api.Response, error) {
+func Handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() { response = trainingprivacy.NoStore(response) }()
+	if err := trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).Require(event.PathParameters["owner"]); err != nil {
+		return api.Failure(err), nil
+	}
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/user/timeline/list/privacy_test.go
+++ b/backend/user/timeline/list/privacy_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"testing"
+)
+
+type privateRepository struct{}
+
+func (privateRepository) GetTrainingPrivacyUser(name string) (*database.User, error) {
+	return &database.User{Username: name, TrainingVisibility: database.TrainingVisibilityPrivate}, nil
+}
+func (privateRepository) GetTrainingPrivacyFollower(string, string) (*database.FollowerEntry, error) {
+	return nil, nil
+}
+func TestPrivateActivityDeniedBeforeDataAccess(t *testing.T) {
+	oldPrivacy, oldRepo := privacyRepository, repository
+	defer func() { privacyRepository, repository = oldPrivacy, oldRepo }()
+	privacyRepository = privateRepository{}
+	repository = nil
+	response, err := Handler(context.Background(), api.Request{PathParameters: map[string]string{"owner": "someone", "id": "old-entry", "year": "2024"}, Body: `{"content":"test"}`})
+	if err != nil || response.StatusCode != 403 {
+		t.Fatalf("got %+v, %v", response, err)
+	}
+	if response.Headers["Cache-Control"] != "private, no-store" {
+		t.Fatal("missing cache control")
+	}
+}
+
+func (r privateRepository) GetTrainingPrivacyUsers(names []string) ([]*database.User, error) {
+	result := make([]*database.User, 0, len(names))
+	for _, name := range names {
+		user, err := r.GetTrainingPrivacyUser(name)
+		if err != nil {
+			return nil, err
+		}
+		if user != nil {
+			result = append(result, user)
+		}
+	}
+	return result, nil
+}

--- a/backend/user/update/main.go
+++ b/backend/user/update/main.go
@@ -55,6 +55,10 @@ func Handler(ctx context.Context, event api.Request) (api.Response, error) {
 		return api.Failure(errors.Wrap(400, "Invalid request: unable to unmarshal request body", "", err)), nil
 	}
 
+	if update.TrainingVisibility != nil && !update.TrainingVisibility.Valid() {
+		return api.Failure(errors.New(400, "Invalid training visibility", "")), nil
+	}
+
 	autopickCohort := event.QueryStringParameters["autopickCohort"]
 	if autopickCohort == "true" {
 		return handleAutopickCohort(user, update), nil

--- a/backend/yearReviewService/get/main.go
+++ b/backend/yearReviewService/get/main.go
@@ -8,7 +8,10 @@ import (
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/errors"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/api/log"
 	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/trainingprivacy"
 )
+
+var privacyRepository trainingprivacy.Repository = database.DynamoDB
 
 var repository = database.DynamoDB
 
@@ -16,7 +19,11 @@ func main() {
 	lambda.Start(handler)
 }
 
-func handler(ctx context.Context, event api.Request) (api.Response, error) {
+func handler(ctx context.Context, event api.Request) (response api.Response, handlerErr error) {
+	defer func() { response = trainingprivacy.NoStore(response) }()
+	if err := trainingprivacy.New(privacyRepository, api.GetUserInfo(event).Username).Require(event.PathParameters["username"]); err != nil {
+		return api.Failure(err), nil
+	}
 	log.SetRequestId(event.RequestContext.RequestID)
 	log.Infof("Event: %#v", event)
 

--- a/backend/yearReviewService/get/privacy_test.go
+++ b/backend/yearReviewService/get/privacy_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/api"
+	"github.com/jackstenglein/chess-dojo-scheduler/backend/database"
+	"testing"
+)
+
+type privateRepository struct{}
+
+func (privateRepository) GetTrainingPrivacyUser(name string) (*database.User, error) {
+	return &database.User{Username: name, TrainingVisibility: database.TrainingVisibilityPrivate}, nil
+}
+func (privateRepository) GetTrainingPrivacyFollower(string, string) (*database.FollowerEntry, error) {
+	return nil, nil
+}
+func TestPrivateActivityDeniedBeforeDataAccess(t *testing.T) {
+	oldPrivacy, oldRepo := privacyRepository, repository
+	defer func() { privacyRepository, repository = oldPrivacy, oldRepo }()
+	privacyRepository = privateRepository{}
+	repository = nil
+	response, err := handler(context.Background(), api.Request{PathParameters: map[string]string{"username": "someone", "id": "old-entry", "year": "2024"}, Body: `{"content":"test"}`})
+	if err != nil || response.StatusCode != 403 {
+		t.Fatalf("got %+v, %v", response, err)
+	}
+	if response.Headers["Cache-Control"] != "private, no-store" {
+		t.Fatal("missing cache control")
+	}
+}
+
+func (r privateRepository) GetTrainingPrivacyUsers(names []string) ([]*database.User, error) {
+	result := make([]*database.User, 0, len(names))
+	for _, name := range names {
+		user, err := r.GetTrainingPrivacyUser(name)
+		if err != nil {
+			return nil, err
+		}
+		if user != nil {
+			result = append(result, user)
+		}
+	}
+	return result, nil
+}

--- a/backend/yearReviewService/serverless.yml
+++ b/backend/yearReviewService/serverless.yml
@@ -33,7 +33,20 @@ functions:
       - httpApi:
           path: /public/yearreview/{username}/{year}
           method: get
+      - httpApi:
+          path: /yearreview/{username}/{year}
+          method: get
+          authorizer:
+            type: jwt
+            id: ${param:apiAuthorizer}
     iamRoleStatements:
+      - Effect: Allow
+        Action:
+          - dynamodb:GetItem
+          - dynamodb:BatchGetItem
+        Resource:
+          - ${param:UsersTableArn}
+          - ${param:FollowersTableArn}
       - Effect: Allow
         Action:
           - dynamodb:GetItem

--- a/common/src/database/user.ts
+++ b/common/src/database/user.ts
@@ -21,7 +21,17 @@ export interface UserExamSummary {
     rating: number;
 }
 
+export enum TrainingVisibility {
+    Public = 'PUBLIC',
+    Members = 'DOJO_MEMBERS',
+    Mutuals = 'MUTUALS',
+    Private = 'PRIVATE',
+}
+
 export interface User {
+    trainingVisibility?: TrainingVisibility;
+    canViewTraining?: boolean;
+
     username: string;
     displayName: string;
     discordUsername: string;

--- a/frontend/messages/de.json
+++ b/frontend/messages/de.json
@@ -4194,5 +4194,14 @@
         "playAsWhite": "Als Weiß spielen",
         "playAsBlack": "Als Schwarz spielen",
         "randomColor": "Zufällige Farbe"
+    },
+    "trainingPrivacy": {
+        "label": "Sichtbarkeit des Trainings",
+        "helperText": "Legt fest, wer dein Trainingsprofil, deine Aktivitäten und deinen Fortschritt auf der Website sehen kann.",
+        "public": "Öffentlich",
+        "private": "Privat",
+        "members": "Nur Dojo-Mitglieder (aktive Abonnenten)",
+        "mutuals": "Nur gegenseitige Follower (ihr folgt einander)",
+        "denied": "Die Trainingsaktivität dieses Nutzers ist privat."
     }
 }

--- a/frontend/messages/en.json
+++ b/frontend/messages/en.json
@@ -4194,5 +4194,14 @@
         "playAsWhite": "Play as White",
         "playAsBlack": "Play as Black",
         "randomColor": "Random Color"
+    },
+    "trainingPrivacy": {
+        "label": "Training visibility",
+        "helperText": "Controls your training profile, activity, and progress across the site.",
+        "public": "Public",
+        "private": "Private",
+        "members": "Dojo Members Only (active subscribers)",
+        "mutuals": "Mutuals Only (you follow each other)",
+        "denied": "This user's training activity is private."
     }
 }

--- a/frontend/messages/es.json
+++ b/frontend/messages/es.json
@@ -4194,5 +4194,14 @@
         "playAsWhite": "Juega como Blanco",
         "playAsBlack": "Juega como Negro",
         "randomColor": "Color aleatorio"
+    },
+    "trainingPrivacy": {
+        "label": "Visibilidad del entrenamiento",
+        "helperText": "Controla la visibilidad de tu perfil de entrenamiento, actividad y progreso en todo el sitio.",
+        "public": "Público",
+        "private": "Privado",
+        "members": "Solo miembros del Dojo (suscriptores activos)",
+        "mutuals": "Solo seguidores mutuos (os seguís mutuamente)",
+        "denied": "La actividad de entrenamiento de este usuario es privada."
     }
 }

--- a/frontend/messages/fr.json
+++ b/frontend/messages/fr.json
@@ -4194,5 +4194,14 @@
         "playAsWhite": "Jouer les Blancs",
         "playAsBlack": "Jouer les Noirs",
         "randomColor": "Couleur aléatoire"
+    },
+    "trainingPrivacy": {
+        "label": "Visibilité de l’entraînement",
+        "helperText": "Contrôle la visibilité de votre profil d’entraînement, de votre activité et de votre progression sur le site.",
+        "public": "Public",
+        "private": "Privé",
+        "members": "Membres du Dojo uniquement (abonnés actifs)",
+        "mutuals": "Abonnements réciproques uniquement (vous vous suivez mutuellement)",
+        "denied": "L’activité d’entraînement de cet utilisateur est privée."
     }
 }

--- a/frontend/messages/it.json
+++ b/frontend/messages/it.json
@@ -4194,5 +4194,14 @@
         "playAsWhite": "Gioca con il Bianco",
         "playAsBlack": "Gioca con il Nero",
         "randomColor": "Colore casuale"
+    },
+    "trainingPrivacy": {
+        "label": "Visibilità dell’allenamento",
+        "helperText": "Controlla la visibilità del tuo profilo di allenamento, delle tue attività e dei tuoi progressi sul sito.",
+        "public": "Pubblico",
+        "private": "Privato",
+        "members": "Solo membri del Dojo (abbonati attivi)",
+        "mutuals": "Solo follower reciproci (vi seguite a vicenda)",
+        "denied": "L’attività di allenamento di questo utente è privata."
     }
 }

--- a/frontend/messages/pseudo.json
+++ b/frontend/messages/pseudo.json
@@ -4194,5 +4194,14 @@
         "playAsWhite": "[PlayMaia.playAsWhite]",
         "playAsBlack": "[PlayMaia.playAsBlack]",
         "randomColor": "[PlayMaia.randomColor]"
+    },
+    "trainingPrivacy": {
+        "label": "[T] Training visibility",
+        "helperText": "[T] Controls your training profile, activity, and progress across the site.",
+        "public": "[T] Public",
+        "private": "[T] Private",
+        "members": "[T] Dojo Members Only (active subscribers)",
+        "mutuals": "[T] Mutuals Only (you follow each other)",
+        "denied": "[T] This user's training activity is private."
     }
 }

--- a/frontend/messages/pt.json
+++ b/frontend/messages/pt.json
@@ -4194,5 +4194,14 @@
         "playAsWhite": "Jogue como Branco",
         "playAsBlack": "Jogue como Preto",
         "randomColor": "Cor aleatória"
+    },
+    "trainingPrivacy": {
+        "label": "Visibilidade do treino",
+        "helperText": "Controla a visibilidade do seu perfil de treino, atividade e progresso em todo o site.",
+        "public": "Público",
+        "private": "Privado",
+        "members": "Somente membros do Dojo (assinantes ativos)",
+        "mutuals": "Somente seguidores mútuos (vocês seguem um ao outro)",
+        "denied": "A atividade de treino deste usuário é privada."
     }
 }

--- a/frontend/playwright/tests/e2e/profile/trainingPlan/ProgressHistory.spec.ts
+++ b/frontend/playwright/tests/e2e/profile/trainingPlan/ProgressHistory.spec.ts
@@ -286,7 +286,7 @@ test.describe('ProgressHistory', () => {
         });
 
         // Mock timeline get route, and abort other timeline requests
-        await page.route(`${getEnv('apiBaseUrl')}/public/user/*/timeline`, async (route) => {
+        await page.route(`${getEnv('apiBaseUrl')}/user/*/timeline`, async (route) => {
             if (route.request().method() === 'GET') {
                 await route.fulfill({
                     status: 200,

--- a/frontend/playwright/tests/e2e/profile/trainingPlan/TrainingPlan.spec.ts
+++ b/frontend/playwright/tests/e2e/profile/trainingPlan/TrainingPlan.spec.ts
@@ -165,7 +165,7 @@ async function mockRequirements(page: Page, requirements: unknown[]) {
 }
 
 async function mockEmptyTimeline(page: Page) {
-    await page.route(`${getEnv('apiBaseUrl')}/public/user/*/timeline`, async (route) => {
+    await page.route(`${getEnv('apiBaseUrl')}/user/*/timeline`, async (route) => {
         await route.fulfill({
             status: 200,
             contentType: 'application/json',

--- a/frontend/playwright/tests/e2e/recent/recent.spec.ts
+++ b/frontend/playwright/tests/e2e/recent/recent.spec.ts
@@ -7,7 +7,7 @@ const fixedDate = new Date(2023, 8, 6); // month is 0-indexed
 test.describe('Graduations', () => {
     test.beforeEach(async ({ page }) => {
         await page.clock.install({ time: fixedDate });
-        await interceptApi(page, 'GET', '/public/graduations', {
+        await interceptApi(page, 'GET', '/graduations', {
             fixture: 'recent/graduations.json',
         });
         await page.goto('/recent');
@@ -59,7 +59,7 @@ test.describe('Graduations', () => {
 
 test.describe('No Graduations', () => {
     test('displays correct message when no graduations', async ({ page }) => {
-        await interceptApi(page, 'GET', '/public/graduations', {
+        await interceptApi(page, 'GET', '/graduations', {
             fixture: 'recent/noGraduations.json',
         });
         await page.goto('/recent');

--- a/frontend/src/api/axiosService.ts
+++ b/frontend/src/api/axiosService.ts
@@ -67,3 +67,12 @@ axiosService.interceptors.response.use(
         return Promise.reject(err);
     },
 );
+
+/** Selects a verified-auth route for signed-in viewers and the public route otherwise. */
+export async function viewerPath(
+    publicPath: string,
+    authenticatedPath = publicPath.replace('/public/', '/'),
+) {
+    const session = await fetchAuthSession();
+    return session.tokens?.idToken ? authenticatedPath : publicPath;
+}

--- a/frontend/src/api/clubApi.ts
+++ b/frontend/src/api/clubApi.ts
@@ -2,7 +2,7 @@ import { AxiosResponse } from 'axios';
 import { Club, ClubDetails, ClubJoinRequestStatus } from '../database/club';
 import { ScoreboardSummary } from '../database/scoreboard';
 import { User } from '../database/user';
-import { axiosService } from './axiosService';
+import { axiosService, viewerPath } from './axiosService';
 
 /** Provides an API for interacting with clubs. */
 export interface ClubApiContextType {
@@ -145,8 +145,8 @@ export interface GetClubResponse {
  * @param id The id of the club to fetch.
  * @returns An AxiosResponse containing the requested club.
  */
-export function getClub(id: string, scoreboard?: boolean) {
-    return axiosService.get<GetClubResponse>(`/public/clubs/${id}`, {
+export async function getClub(id: string, scoreboard?: boolean) {
+    return axiosService.get<GetClubResponse>(await viewerPath(`/public/clubs/${id}`), {
         params: { scoreboard },
         functionName: 'getClub',
     });

--- a/frontend/src/api/graduationApi.ts
+++ b/frontend/src/api/graduationApi.ts
@@ -1,5 +1,5 @@
 import { Graduation } from '../database/graduation';
-import { axiosService } from './axiosService';
+import { axiosService, viewerPath } from './axiosService';
 
 export interface GraduationApiContextType {
     /**
@@ -35,7 +35,7 @@ async function listGraduations(url: string, params: Record<string, string | unde
     const result: Graduation[] = [];
 
     do {
-        const resp = await axiosService.get<ListGraduationsResponse>(url, {
+        const resp = await axiosService.get<ListGraduationsResponse>(await viewerPath(url), {
             params,
             functionName: 'listGraduations',
         });

--- a/frontend/src/api/newsfeedApi.tsx
+++ b/frontend/src/api/newsfeedApi.tsx
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { TimelineEntry } from '../database/timeline';
-import { axiosService } from './axiosService';
+import { axiosService, viewerPath } from './axiosService';
 
 export interface NewsfeedApiContextType {
     /**
@@ -55,8 +55,8 @@ export interface NewsfeedApiContextType {
  * @param id The id of the timeline entry.
  * @returns An AxiosResponse containing the timeline entry.
  */
-export function getNewsfeedItem(owner: string, id: string) {
-    return axiosService.get<TimelineEntry>(`/public/newsfeed/${owner}/${id}`, {
+export async function getNewsfeedItem(owner: string, id: string) {
+    return axiosService.get<TimelineEntry>(await viewerPath(`/public/newsfeed/${owner}/${id}`), {
         functionName: 'getNewsfeedItem',
     });
 }

--- a/frontend/src/api/userApi.ts
+++ b/frontend/src/api/userApi.ts
@@ -8,7 +8,7 @@ import { Graduation } from '../database/graduation';
 import { UserStatistics } from '../database/statistics';
 import { TimelineEntry } from '../database/timeline';
 import { User, UserSummary } from '../database/user';
-import { axiosService } from './axiosService';
+import { axiosService, viewerPath } from './axiosService';
 
 /**
  * UserApiContextType provides an API for interacting with the current signed-in user.
@@ -214,10 +214,13 @@ export function getUser(idToken: string) {
  * @param username The user to fetch public information for.
  * @returns An AxiosResponse containing the requested user.
  */
-export function getUserPublic(username: string) {
-    return axiosService.get<User>('/public/user/' + username, {
-        functionName: 'getUserPublic',
-    });
+export async function getUserPublic(username: string) {
+    return axiosService.get<User>(
+        await viewerPath('/public/user/' + username, '/user/profile/' + username),
+        {
+            functionName: 'getUserPublic',
+        },
+    );
 }
 
 /** The billing path hint for an admin-only user. */
@@ -313,7 +316,7 @@ export interface ListUserTimelineResponse {
 export async function listUserTimeline(owner: string, startKey?: string) {
     const params = { startKey };
     const resp = await axiosService.get<ListUserTimelineResponse>(
-        `/public/user/${owner}/timeline`,
+        await viewerPath(`/public/user/${owner}/timeline`),
         {
             params,
             functionName: 'listUserTimeline',

--- a/frontend/src/api/yearReviewApi.ts
+++ b/frontend/src/api/yearReviewApi.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { YearReview } from '../database/yearReview';
-import { axiosService } from './axiosService';
+import { axiosService, viewerPath } from './axiosService';
 
 /**
  * Provides an API for interacting with year reviews.
@@ -21,8 +21,11 @@ export interface YearReviewApiContextType {
  * @param year The year to fetch.
  * @returns The year review for the given user and year.
  */
-export function getYearReview(username: string, year: string) {
-    return axiosService.get<YearReview>(`/public/yearreview/${username}/${year}`, {
-        functionName: 'getYearReview',
-    });
+export async function getYearReview(username: string, year: string) {
+    return axiosService.get<YearReview>(
+        await viewerPath(`/public/yearreview/${username}/${year}`),
+        {
+            functionName: 'getYearReview',
+        },
+    );
 }

--- a/frontend/src/app/[locale]/(scoreboard)/newsfeed/(detail)/[owner]/[id]/NewsfeedDetail.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/newsfeed/(detail)/[owner]/[id]/NewsfeedDetail.tsx
@@ -2,14 +2,29 @@
 
 import { useApi } from '@/api/Api';
 import { RequestSnackbar, useRequest } from '@/api/Request';
+import { useAuth } from '@/auth/Auth';
 import NewsfeedItem from '@/components/newsfeed/NewsfeedItem';
 import { TimelineEntry } from '@/database/timeline';
 import LoadingPage from '@/loading/LoadingPage';
 import NotFoundPage from '@/NotFoundPage';
-import { Container } from '@mui/material';
+import { Alert, Container } from '@mui/material';
+import { isAxiosError } from 'axios';
+import { useTranslations } from 'next-intl';
 import { useEffect } from 'react';
 
 export function NewsfeedDetail({ owner, id }: { owner: string; id: string }) {
+    const { user } = useAuth();
+    return (
+        <NewsfeedDetailContent
+            key={`${user?.username ?? 'public'}:${owner}:${id}`}
+            owner={owner}
+            id={id}
+        />
+    );
+}
+
+function NewsfeedDetailContent({ owner, id }: { owner: string; id: string }) {
+    const tPrivacy = useTranslations('trainingPrivacy');
     const api = useApi();
     const request = useRequest<TimelineEntry>();
 
@@ -26,10 +41,9 @@ export function NewsfeedDetail({ owner, id }: { owner: string; id: string }) {
         }
     }, [api, request, owner, id]);
 
-    const reset = request.reset;
-    useEffect(() => {
-        reset();
-    }, [reset, owner, id]);
+    if (isAxiosError(request.error) && request.error.response?.status === 403) {
+        return <Alert severity='info'>{tPrivacy('denied')}</Alert>;
+    }
 
     if (!request.isSent() || request.isLoading()) {
         return <LoadingPage />;

--- a/frontend/src/app/[locale]/(scoreboard)/profile/[username]/ProfilePage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/profile/[username]/ProfilePage.tsx
@@ -39,7 +39,7 @@ import {
     Timeline,
 } from '@mui/icons-material';
 import { TabContext, TabPanel } from '@mui/lab';
-import { Box, Chip, Container, Stack, Tab, Tabs, useMediaQuery } from '@mui/material';
+import { Alert, Box, Chip, Container, Stack, Tab, Tabs, useMediaQuery } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { ReactNode, useEffect, type JSX } from 'react';
 
@@ -52,11 +52,18 @@ export function ProfilePage({ username }: { username?: string }) {
     if (!user) {
         return <NotFoundPage />;
     }
-    return <AuthProfilePage currentUser={user} username={username} />;
+    return (
+        <AuthProfilePage
+            key={`${user.username}:${username ?? user.username}`}
+            currentUser={user}
+            username={username}
+        />
+    );
 }
 
 function AuthProfilePage({ currentUser, username }: { currentUser: User; username?: string }) {
     const t = useTranslations('profile.profilePage');
+    const tPrivacy = useTranslations('trainingPrivacy');
     const api = useApi();
     const request = useRequest<User>();
     const isSmall = useMediaQuery((theme) => theme.breakpoints.down('md'));
@@ -100,11 +107,10 @@ function AuthProfilePage({ currentUser, username }: { currentUser: User; usernam
         return <NotFoundPage />;
     }
 
-    const setFollowerCount = (count: number) => {
-        request.onSuccess({
-            ...user,
-            followerCount: count,
-        });
+    const canViewTraining = currentUserProfile || user.canViewTraining !== false;
+
+    const setFollowerCount = (_count: number) => {
+        request.reset();
     };
 
     return (
@@ -152,7 +158,11 @@ function AuthProfilePage({ currentUser, username }: { currentUser: User; usernam
                 },
             }}
         >
-            <TimelineProvider owner={user.username}>
+            <TimelineProvider
+                key={`${user.username}:${canViewTraining}`}
+                owner={user.username}
+                enabled={canViewTraining}
+            >
                 <Box sx={{ gridArea: 'profile', width: '100%', typography: 'body1' }}>
                     <TabContext value={searchParams.get('view') || 'stats'}>
                         <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
@@ -238,10 +248,18 @@ function AuthProfilePage({ currentUser, username }: { currentUser: User; usernam
                             <CoachTab user={user} />
                         </TabPanel>
                         <TabPanel value='progress' sx={{ px: { xs: 0 }, pl: { lg: 1 } }}>
-                            <TrainingPlanTab user={user} />
+                            {canViewTraining ? (
+                                <TrainingPlanTab user={user} />
+                            ) : (
+                                <Alert severity='info'>{tPrivacy('denied')}</Alert>
+                            )}
                         </TabPanel>
                         <TabPanel value='activity' sx={{ px: 0, pl: { lg: 1 } }}>
-                            <ActivityTab user={user} />
+                            {canViewTraining ? (
+                                <ActivityTab user={user} />
+                            ) : (
+                                <Alert severity='info'>{tPrivacy('denied')}</Alert>
+                            )}
                         </TabPanel>
                         <TabPanel value='games' sx={{ px: 0 }}>
                             <DirectoryCacheProvider>
@@ -278,24 +296,25 @@ function AuthProfilePage({ currentUser, username }: { currentUser: User; usernam
 
                 {currentUserProfile && <SwitchCohortPrompt />}
 
-                <Box sx={{ gridArea: 'userInfo' }}>
+                <Stack spacing={2} sx={{ gridArea: 'userInfo' }}>
                     <UserCard user={user} setFollowerCount={setFollowerCount} />
-                </Box>
+                    {!canViewTraining && <Alert severity='info'>{tPrivacy('denied')}</Alert>}
+                </Stack>
 
-                {!isSmall && (
+                {canViewTraining && !isSmall && (
                     <Box sx={{ gridArea: 'heatmap', display: { xs: 'none', md: 'initial' } }}>
                         <HeatmapCard workGoalHistory={user.workGoalHistory ?? []} />
                     </Box>
                 )}
 
-                {(isSmall || isLarge) && (
+                {canViewTraining && (isSmall || isLarge) && (
                     <Box sx={{ gridArea: 'scorecard' }}>
                         <DojoScoreCard user={user} cohort={user.dojoCohort} />
                     </Box>
                 )}
 
                 <Box sx={{ gridArea: 'badges', display: { xs: 'none', lg: 'initial' } }}>
-                    <BadgeCard user={user} />
+                    {canViewTraining && <BadgeCard user={user} />}
                 </Box>
 
                 {currentUserProfile && (

--- a/frontend/src/app/[locale]/(scoreboard)/profile/[username]/postmortem/[year]/YearReviewPage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/profile/[username]/postmortem/[year]/YearReviewPage.tsx
@@ -3,6 +3,7 @@
 import NotFoundPage from '@/NotFoundPage';
 import { RequestSnackbar, useRequest } from '@/api/Request';
 import { getYearReview } from '@/api/yearReviewApi';
+import { useAuth } from '@/auth/Auth';
 import DojoPointSection from '@/components/profile/yearReview/DojoPointSection';
 import GameSection from '@/components/profile/yearReview/GameSection';
 import GraduationSection from '@/components/profile/yearReview/GraduationSection';
@@ -13,12 +14,25 @@ import { YearReview } from '@/database/yearReview';
 import LoadingPage from '@/loading/LoadingPage';
 import Avatar from '@/profile/Avatar';
 import { ExpandMore } from '@mui/icons-material';
-import { Box, Container, Stack, Typography } from '@mui/material';
+import { Alert, Box, Container, Stack, Typography } from '@mui/material';
+import { isAxiosError } from 'axios';
 import { useTranslations } from 'next-intl';
 import { useEffect } from 'react';
 
 const YearReviewPage = ({ username, year }: { username: string; year: string }) => {
+    const { user } = useAuth();
+    return (
+        <YearReviewContent
+            key={`${user?.username ?? 'public'}:${username}:${year}`}
+            username={username}
+            year={year}
+        />
+    );
+};
+
+const YearReviewContent = ({ username, year }: { username: string; year: string }) => {
     const t = useTranslations('profile.yearReview');
+    const tPrivacy = useTranslations('trainingPrivacy');
     const request = useRequest<YearReview>();
 
     useEffect(() => {
@@ -33,6 +47,10 @@ const YearReviewPage = ({ username, year }: { username: string; year: string }) 
                 });
         }
     });
+
+    if (isAxiosError(request.error) && request.error.response?.status === 403) {
+        return <Alert severity='info'>{tPrivacy('denied')}</Alert>;
+    }
 
     if (!request.isSent() || request.isLoading()) {
         return <LoadingPage />;

--- a/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/profile/edit/ProfileEditorPage.tsx
@@ -23,6 +23,7 @@ import {
 import { useRouter } from '@/hooks/useRouter';
 import { DEFAULT_LOCALE, setLocaleCookie } from '@/i18n/locales';
 import { logger } from '@/logging/logger';
+import { TrainingVisibility } from '@jackstenglein/chess-dojo-common/src/database/user';
 import InfoIcon from '@mui/icons-material/Info';
 import KeyIcon from '@mui/icons-material/Key';
 import MonetizationOnIcon from '@mui/icons-material/MonetizationOn';
@@ -44,7 +45,9 @@ import {
     DialogTitle,
     Divider,
     Grid,
+    MenuItem,
     Stack,
+    TextField,
     Typography,
 } from '@mui/material';
 import { useTranslations } from 'next-intl';
@@ -158,6 +161,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
     const router = useRouter();
     const t = useTranslations('profile.editor');
     const tRating = useTranslations('enums.ratingSystem');
+    const tPrivacy = useTranslations('trainingPrivacy');
 
     const [displayName, setDisplayName] = useState(user.displayName || '');
     const [dojoCohort, setDojoCohort] = useState(
@@ -167,6 +171,9 @@ export function ProfileEditorPage({ user }: { user: User }) {
     const [coachBio, setCoachBio] = useState(user.coachBio || '');
     const [timezone, setTimezone] = useState(user.timezoneOverride || DefaultTimezone);
     const [language, setLanguage] = useState(user.language || DEFAULT_LOCALE);
+    const [trainingVisibility, setTrainingVisibility] = useState(
+        user.trainingVisibility ?? TrainingVisibility.Public,
+    );
 
     const [ratingSystem, setRatingSystem] = useState(user.ratingSystem);
     const [ratingEditors, setRatingEditors] = useState(getRatingEditors(user.ratings));
@@ -188,6 +195,10 @@ export function ProfileEditorPage({ user }: { user: User }) {
         {
             displayName: displayName.trim(),
             bio: bio === '' && user.bio === undefined ? undefined : bio,
+            trainingVisibility:
+                trainingVisibility === (user.trainingVisibility ?? TrainingVisibility.Public)
+                    ? user.trainingVisibility
+                    : trainingVisibility,
             coachBio: coachBio === '' && user.coachBio === undefined ? undefined : coachBio,
             timezoneOverride:
                 timezone === DefaultTimezone && !user.timezoneOverride
@@ -300,6 +311,7 @@ export function ProfileEditorPage({ user }: { user: User }) {
     };
 
     const onCancelPersonal = () => {
+        setTrainingVisibility(user.trainingVisibility ?? TrainingVisibility.Public);
         setDisplayName(user.displayName || '');
         setBio(user.bio || '');
         setCoachBio(user.coachBio || '');
@@ -488,24 +500,50 @@ export function ProfileEditorPage({ user }: { user: User }) {
                         )}
 
                         <Stack spacing={2}>
-                            <PersonalInfoEditor
-                                user={user}
-                                displayName={displayName}
-                                setDisplayName={setDisplayName}
-                                bio={bio}
-                                setBio={setBio}
-                                coachBio={coachBio}
-                                setCoachBio={setCoachBio}
-                                timezone={timezone}
-                                setTimezone={setTimezone}
-                                language={language}
-                                setLanguage={setLanguage}
-                                profilePictureUrl={profilePictureUrl}
-                                setProfilePictureUrl={setProfilePictureUrl}
-                                setProfilePictureData={setProfilePictureData}
-                                errors={errors}
-                                request={request}
-                            />
+                            <Stack spacing={4}>
+                                <PersonalInfoEditor
+                                    user={user}
+                                    displayName={displayName}
+                                    setDisplayName={setDisplayName}
+                                    bio={bio}
+                                    setBio={setBio}
+                                    coachBio={coachBio}
+                                    setCoachBio={setCoachBio}
+                                    timezone={timezone}
+                                    setTimezone={setTimezone}
+                                    language={language}
+                                    setLanguage={setLanguage}
+                                    profilePictureUrl={profilePictureUrl}
+                                    setProfilePictureUrl={setProfilePictureUrl}
+                                    setProfilePictureData={setProfilePictureData}
+                                    errors={errors}
+                                    request={request}
+                                />
+                                <TextField
+                                    select
+                                    label={tPrivacy('label')}
+                                    value={trainingVisibility}
+                                    onChange={(event) =>
+                                        setTrainingVisibility(
+                                            event.target.value as TrainingVisibility,
+                                        )
+                                    }
+                                    helperText={tPrivacy('helperText')}
+                                >
+                                    <MenuItem value={TrainingVisibility.Public}>
+                                        {tPrivacy('public')}
+                                    </MenuItem>
+                                    <MenuItem value={TrainingVisibility.Private}>
+                                        {tPrivacy('private')}
+                                    </MenuItem>
+                                    <MenuItem value={TrainingVisibility.Members}>
+                                        {tPrivacy('members')}
+                                    </MenuItem>
+                                    <MenuItem value={TrainingVisibility.Mutuals}>
+                                        {tPrivacy('mutuals')}
+                                    </MenuItem>
+                                </TextField>
+                            </Stack>
                             <Stack
                                 direction='row'
                                 spacing={2}

--- a/frontend/src/components/profile/activity/useTimeline.tsx
+++ b/frontend/src/components/profile/activity/useTimeline.tsx
@@ -35,10 +35,15 @@ export const useTimelineContext = () => {
 
 interface TimelineProviderProps {
     owner: string;
+    enabled?: boolean;
     children: ReactNode;
 }
 
-export const TimelineProvider: React.FC<TimelineProviderProps> = ({ owner, children }) => {
+export const TimelineProvider: React.FC<TimelineProviderProps> = ({
+    owner,
+    enabled = true,
+    children,
+}) => {
     const [entries, setEntries] = useState<TimelineEntry[]>([]);
     const [startKey, setStartKey] = useState<string>();
     const request = useRequest();
@@ -84,10 +89,10 @@ export const TimelineProvider: React.FC<TimelineProviderProps> = ({ owner, child
     );
 
     useEffect(() => {
-        if (owner && !request.isSent()) {
+        if (enabled && owner && !request.isSent()) {
             void fetchEntriesForLastYear(owner, startKey);
         }
-    }, [owner, request, fetchEntriesForLastYear, startKey]);
+    }, [enabled, owner, request, fetchEntriesForLastYear, startKey]);
 
     const reset = request.reset;
 

--- a/frontend/src/components/profile/stats/StatsTab.tsx
+++ b/frontend/src/components/profile/stats/StatsTab.tsx
@@ -146,9 +146,11 @@ const StatsTab: React.FC<StatsTabProps> = ({ user }) => {
                 );
             })}
 
-            <DrillRatingsCard mateInOneRating={user.mateInOneRating} />
+            {user.canViewTraining !== false && (
+                <DrillRatingsCard mateInOneRating={user.mateInOneRating} />
+            )}
 
-            <TacticsScoreCard user={user} />
+            {user.canViewTraining !== false && <TacticsScoreCard user={user} />}
         </Stack>
     );
 };

--- a/frontend/src/components/profile/trainingPlan/MiniScoreboard.test.tsx
+++ b/frontend/src/components/profile/trainingPlan/MiniScoreboard.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MiniScoreboard } from './MiniScoreboard';
+
+const { getScoreboard, viewer } = vi.hoisted(() => ({
+    getScoreboard: vi.fn(),
+    viewer: {
+        username: 'self',
+        displayName: 'My profile',
+        dojoCohort: '1200-1300',
+        totalDojoScore: 1,
+        progress: {},
+        minutesSpent: {},
+    },
+}));
+vi.mock('@/api/Api', () => ({ useApi: () => ({ getScoreboard }) }));
+vi.mock('@/auth/Auth', () => ({ useAuth: () => ({ user: viewer }) }));
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }));
+vi.mock('@/profile/Avatar', () => ({ default: () => null }));
+vi.mock('@/scoreboard/CohortIcon', () => ({ default: () => null }));
+vi.mock('@/components/navigation/Link', () => ({ Link: 'a' }));
+
+describe('mini scoreboard privacy', () => {
+    beforeEach(() => getScoreboard.mockReset());
+
+    it('excludes restricted profiles before selecting the top five and includes the owner', async () => {
+        getScoreboard.mockResolvedValue([
+            {
+                username: 'hidden',
+                displayName: 'Hidden player',
+                canViewTraining: false,
+                progress: {},
+                totalDojoScore: 99999,
+            },
+            ...Array.from({ length: 6 }, (_, i) => ({
+                username: `p${i}`,
+                displayName: `Player ${i}`,
+                progress: {},
+                totalDojoScore: 100 - i,
+            })),
+        ]);
+        render(<MiniScoreboard cohort='1200-1300' />);
+        await waitFor(() => expect(screen.getByText('Player 4')).toBeInTheDocument());
+        expect(screen.queryByText('Hidden player')).not.toBeInTheDocument();
+        expect(screen.queryByText('Player 5')).not.toBeInTheDocument();
+        expect(screen.getByText('My profile')).toBeInTheDocument();
+        expect(screen.getByText('#7')).toBeInTheDocument();
+    });
+});

--- a/frontend/src/components/profile/trainingPlan/MiniScoreboard.tsx
+++ b/frontend/src/components/profile/trainingPlan/MiniScoreboard.tsx
@@ -88,6 +88,7 @@ export function MiniScoreboard({ cohort }: { cohort: string }) {
     }
 
     let allPlayers = (request.data || [])
+        .filter((row) => !('canViewTraining' in row && row.canViewTraining === false))
         .filter(isUser)
         .map((p) => p as User & { isCurrent?: boolean; actualRank?: number });
 

--- a/frontend/src/database/scoreboard.ts
+++ b/frontend/src/database/scoreboard.ts
@@ -6,6 +6,7 @@ import { User } from './user';
  */
 export type ScoreboardSummary = Pick<
     User,
+    | 'canViewTraining'
     | 'username'
     | 'displayName'
     | 'graduationCohorts'

--- a/frontend/src/scoreboard/Scoreboard.tsx
+++ b/frontend/src/scoreboard/Scoreboard.tsx
@@ -37,6 +37,7 @@ import {
     getRatingSystem,
     getStartRating,
 } from './scoreboardData';
+import { isTrainingPrivate, privateTrainingColumn } from './trainingPrivacy';
 
 type ScoreboardT = ReturnType<typeof useTranslations<'scoreboard'>>;
 type RatingT = ReturnType<typeof useTranslations<'enums.ratingSystem'>>;
@@ -68,8 +69,19 @@ function getRankColumn(t: ScoreboardT): GridColDef<ScoreboardRow> {
         field: 'rank',
         headerName: t('rankColumn'),
         renderHeader: () => '',
-        valueGetter: (_value, row, _column, api) =>
-            api.current.getSortedRowIds().indexOf(row.username.replace('#pinned', '')) + 1,
+        valueGetter: (_value, row, _column, api) => {
+            const trainingSort = api.current
+                .getSortModel()
+                .some((sort) => api.current.getColumn(sort.field)?.getSortComparator !== undefined);
+            if (trainingSort && isTrainingPrivate(row)) return null;
+            const ids = api.current
+                .getSortedRowIds()
+                .filter(
+                    (id) =>
+                        !trainingSort || !isTrainingPrivate(api.current.getRow<ScoreboardRow>(id)),
+                );
+            return ids.indexOf(row.username.replace('#pinned', '')) + 1;
+        },
         sortable: false,
         filterable: false,
         align: 'center',
@@ -588,11 +600,13 @@ const Scoreboard: React.FC<ScoreboardProps> = ({
     const columns = useMemo(
         () =>
             [actionColumn].concat(
-                isSummary ? summaryUserInfoColumns : defaultUserInfoColumns,
+                (isSummary ? summaryUserInfoColumns : defaultUserInfoColumns).map((column) =>
+                    column.field === 'previousCohort' ? privateTrainingColumn(column) : column,
+                ),
                 ratingsColumns,
-                trainingPlanColumns,
-                timeSpentColumns,
-                requirementColumns,
+                trainingPlanColumns.map(privateTrainingColumn),
+                timeSpentColumns.map(privateTrainingColumn),
+                requirementColumns.map(privateTrainingColumn),
             ),
         [
             actionColumn,

--- a/frontend/src/scoreboard/trainingPrivacy.test.tsx
+++ b/frontend/src/scoreboard/trainingPrivacy.test.tsx
@@ -1,0 +1,100 @@
+import type { User } from '@/database/user';
+import { DataGridPro, type GridColDef, type GridSortCellParams } from '@mui/x-data-grid-pro';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ScoreboardRow } from './scoreboardData';
+import { privateTrainingColumn } from './trainingPrivacy';
+
+const visible = { username: 'visible', displayName: 'Visible', totalDojoScore: 20 } as User;
+const hidden = { username: 'hidden', displayName: 'Hidden', canViewTraining: false } as User;
+const another = { username: 'another', displayName: 'Another', canViewTraining: false } as User;
+const rows = [visible, hidden, another];
+const params = (row: User) =>
+    ({
+        id: row.username,
+        api: { getRow: (id: string) => rows.find((r) => r.username === id) },
+    }) as GridSortCellParams;
+
+describe('training scoreboard privacy', () => {
+    afterEach(cleanup);
+
+    it('renders Private cells and keeps users available for rating sorting in the grid', async () => {
+        const scoreColumn = privateTrainingColumn({
+            field: 'totalDojoScore',
+            headerName: 'Training score',
+            width: 160,
+        });
+        const ratedRows = [
+            { ...visible, rating: 1000 },
+            { ...hidden, rating: 2000 },
+        ];
+        render(
+            <div style={{ height: 500, width: 700 }}>
+                <DataGridPro
+                    disableVirtualization
+                    rows={ratedRows}
+                    getRowId={(row) => row.username}
+                    columns={[
+                        { field: 'displayName', headerName: 'Name', width: 160 },
+                        { field: 'rating', headerName: 'Rating', type: 'number', width: 160 },
+                        scoreColumn,
+                    ]}
+                    initialState={{
+                        sorting: { sortModel: [{ field: 'totalDojoScore', sort: 'desc' }] },
+                    }}
+                />
+            </div>,
+        );
+        const order = () =>
+            screen
+                .getAllByRole('row')
+                .map((row) => row.getAttribute('data-id'))
+                .filter(Boolean);
+        await waitFor(() => expect(order()).toEqual(['visible', 'hidden']));
+        expect(screen.getByText('Private')).toBeInTheDocument();
+        fireEvent.click(screen.getByRole('columnheader', { name: /Training score/ }));
+        fireEvent.click(screen.getByRole('columnheader', { name: /Training score/ }));
+        await waitFor(() => expect(order()).toEqual(['visible', 'hidden']));
+        fireEvent.click(screen.getByRole('columnheader', { name: /Rating/ }));
+        fireEvent.click(screen.getByRole('columnheader', { name: /Rating/ }));
+        await waitFor(() => expect(order()).toEqual(['hidden', 'visible']));
+    });
+    it.each(['asc', 'desc'] as const)(
+        'keeps restricted rows last and alphabetical for %s',
+        (direction) => {
+            const column = privateTrainingColumn({ field: 'totalDojoScore' });
+            const compare = column.getSortComparator?.(direction);
+            if (!compare) throw new Error('Missing comparator');
+            expect(compare(20, null, params(visible), params(hidden))).toBeLessThan(0);
+            expect(compare(null, 20, params(hidden), params(visible))).toBeGreaterThan(0);
+            expect(compare(null, null, params(another), params(hidden))).toBeLessThan(0);
+        },
+    );
+
+    it('does not invoke progress calculations or renderers for a redacted row', () => {
+        const getter = vi.fn(() => 20);
+        const renderer = vi.fn(() => '20');
+        const column = privateTrainingColumn({
+            field: 'cohortScore',
+            valueGetter: getter,
+            renderCell: renderer,
+        });
+        expect(column.valueGetter?.(undefined as never, hidden, column, {} as never)).toBeNull();
+        expect(column.renderCell?.({ row: hidden } as never)).toBe('Private');
+        expect(column.valueFormatter?.(null as never, hidden, column, {} as never)).toBe('Private');
+        expect(getter).not.toHaveBeenCalled();
+        expect(renderer).not.toHaveBeenCalled();
+    });
+
+    it('preserves normal values and formatting for authorized viewers', () => {
+        const original: GridColDef<ScoreboardRow> = {
+            field: 'totalDojoScore',
+            valueFormatter: (value) => `${value} points`,
+        };
+        const column = privateTrainingColumn(original);
+        expect(column.valueGetter?.(undefined as never, visible, column, {} as never)).toBe(20);
+        expect(column.valueFormatter?.(20 as never, visible, column, {} as never)).toBe(
+            '20 points',
+        );
+    });
+});

--- a/frontend/src/scoreboard/trainingPrivacy.tsx
+++ b/frontend/src/scoreboard/trainingPrivacy.tsx
@@ -1,0 +1,51 @@
+import { gridStringOrNumberComparator, type GridApi, type GridColDef } from '@mui/x-data-grid-pro';
+import type { ScoreboardRow } from './scoreboardData';
+
+export function isTrainingPrivate(row: ScoreboardRow | null): boolean {
+    return row !== null && 'canViewTraining' in row && row.canViewTraining === false;
+}
+
+/** Keep redacted rows last in either direction, without comparing their hidden values. */
+export function privateTrainingColumn(
+    column: GridColDef<ScoreboardRow>,
+): GridColDef<ScoreboardRow> {
+    return {
+        ...column,
+        valueGetter: (value, row, col, api): unknown =>
+            isTrainingPrivate(row)
+                ? null
+                : column.valueGetter
+                  ? column.valueGetter(value, row, col, api)
+                  : row[column.field as keyof ScoreboardRow],
+        renderCell: (params) =>
+            isTrainingPrivate(params.row)
+                ? 'Private'
+                : column.renderCell
+                  ? column.renderCell(params)
+                  : (params.formattedValue as string),
+        valueFormatter: (value, row, col, api): unknown =>
+            isTrainingPrivate(row)
+                ? 'Private'
+                : column.valueFormatter
+                  ? column.valueFormatter(value, row, col, api)
+                  : value,
+        getSortComparator: (direction) => {
+            return (v1, v2, p1, p2) => {
+                const a = (p1.api as GridApi).getRow<ScoreboardRow>(p1.id);
+                const b = (p2.api as GridApi).getRow<ScoreboardRow>(p2.id);
+                if (!a || !b) return 0;
+                const aPrivate = isTrainingPrivate(a);
+                const bPrivate = isTrainingPrivate(b);
+                if (aPrivate && bPrivate)
+                    return (
+                        a.displayName.localeCompare(b.displayName) ||
+                        a.username.localeCompare(b.username)
+                    );
+                if (aPrivate !== bPrivate) return aPrivate ? 1 : -1;
+                return (
+                    (direction === 'desc' ? -1 : 1) * gridStringOrNumberComparator(v1, v2, p1, p2)
+                );
+            };
+        },
+    };
+}

--- a/mobile/src/api/Api.tsx
+++ b/mobile/src/api/Api.tsx
@@ -2,55 +2,12 @@ import { createContext, ReactNode, useContext, useMemo } from 'react';
 
 import { useAuth } from '../auth/Auth';
 
-import { User } from '../database/user';
 import { Event } from '../database/event';
 import { Requirement } from '../database/requirement';
 import { TimelineEntry } from '../database/timeline';
+import { User } from '../database/user';
 
-import {
-    UserApiContextType,
-    getUser,
-    getUserPublic,
-    listUsersByCohort,
-    searchUsers,
-    updateUser,
-    updateUserProgress,
-    graduate,
-    updateUserTimeline,
-    getUserStatistics,
-    checkUserAccess,
-    listUserTimeline,
-    editFollower,
-    getFollower,
-    listFollowers,
-    listFollowing,
-} from './userApi';
-import {
-    GameApiContextType,
-    CreateGameRequest,
-    createGame,
-    getGame,
-    listGamesByCohort,
-    listGamesByOwner,
-    listFeaturedGames,
-    createComment,
-    featureGame,
-    updateGame,
-    deleteGame,
-    listGamesByOpening,
-} from './gameApi';
-import {
-    RequirementApiContextType,
-    getRequirement,
-    listRequirements,
-    setRequirement,
-} from './requirementApi';
-import {
-    GraduationApiContextType,
-    listGraduationsByCohort,
-    listGraduationsByOwner,
-    listGraduationsByDate,
-} from './graduationApi';
+import { TournamentType } from '../database/tournament';
 import {
     bookEvent,
     cancelEvent,
@@ -60,7 +17,45 @@ import {
     listEvents,
     setEvent,
 } from './eventApi';
+import {
+    createComment,
+    createGame,
+    CreateGameRequest,
+    deleteGame,
+    featureGame,
+    GameApiContextType,
+    getGame,
+    listFeaturedGames,
+    listGamesByCohort,
+    listGamesByOpening,
+    listGamesByOwner,
+    updateGame,
+} from './gameApi';
+import {
+    GraduationApiContextType,
+    listGraduationsByCohort,
+    listGraduationsByDate,
+    listGraduationsByOwner,
+} from './graduationApi';
+import {
+    createNewsfeedComment,
+    getNewsfeedItem,
+    listNewsfeed,
+    NewsfeedApiContextType,
+    setNewsfeedReaction,
+} from './newsfeedApi';
+import {
+    deleteNotification,
+    listNotifications,
+    NotificationApiContextType,
+} from './notificationApi';
 import { getCourse, listCourses, OpeningApiContextType } from './openingApi';
+import {
+    getRequirement,
+    listRequirements,
+    RequirementApiContextType,
+    setRequirement,
+} from './requirementApi';
 import {
     getLeaderboard,
     getOpenClassical,
@@ -73,19 +68,24 @@ import {
     TimePeriod,
     TournamentApiContextType,
 } from './tournamentApi';
-import { TournamentType } from '../database/tournament';
 import {
-    NotificationApiContextType,
-    listNotifications,
-    deleteNotification,
-} from './notificationApi';
-import {
-    createNewsfeedComment,
-    getNewsfeedItem,
-    listNewsfeed,
-    NewsfeedApiContextType,
-    setNewsfeedReaction,
-} from './newsfeedApi';
+    checkUserAccess,
+    editFollower,
+    getFollower,
+    getUser,
+    getUserPublic,
+    getUserStatistics,
+    graduate,
+    listFollowers,
+    listFollowing,
+    listUsersByCohort,
+    listUserTimeline,
+    searchUsers,
+    updateUser,
+    updateUserProgress,
+    updateUserTimeline,
+    UserApiContextType,
+} from './userApi';
 
 /**
  * ApiContextType defines the interface of the API as available through ApiProvider.
@@ -123,7 +123,7 @@ export function ApiProvider({ children }: { children: ReactNode }) {
         return {
             checkUserAccess: () => checkUserAccess(idToken),
             getUser: () => getUser(idToken),
-            getUserPublic: (username: string) => getUserPublic(username),
+            getUserPublic: (username: string) => getUserPublic(idToken, username),
             listUserTimeline: (owner: string, startKey?: string) =>
                 listUserTimeline(idToken, owner, startKey),
             listUsersByCohort: (cohort: string, startKey?: string) =>
@@ -136,7 +136,7 @@ export function ApiProvider({ children }: { children: ReactNode }) {
                 requirementId: string,
                 incrementalCount: number,
                 incrementalMinutesSpent: number,
-                date: Date | null
+                date: Date | null,
             ) =>
                 updateUserProgress(
                     idToken,
@@ -145,7 +145,7 @@ export function ApiProvider({ children }: { children: ReactNode }) {
                     incrementalCount,
                     incrementalMinutesSpent,
                     date,
-                    auth.updateUser
+                    auth.updateUser,
                 ),
             updateUserTimeline: (
                 requirementId: string,
@@ -153,7 +153,7 @@ export function ApiProvider({ children }: { children: ReactNode }) {
                 updated: TimelineEntry[],
                 deleted: TimelineEntry[],
                 count: number,
-                minutesSpent: number
+                minutesSpent: number,
             ) =>
                 updateUserTimeline(
                     idToken,
@@ -163,7 +163,7 @@ export function ApiProvider({ children }: { children: ReactNode }) {
                     deleted,
                     count,
                     minutesSpent,
-                    auth.updateUser
+                    auth.updateUser,
                 ),
             graduate: (comments: string) => graduate(idToken, comments, auth.updateUser),
             getUserStatistics: () => getUserStatistics(),
@@ -194,7 +194,7 @@ export function ApiProvider({ children }: { children: ReactNode }) {
                 cohort: string,
                 startKey?: string,
                 startDate?: string,
-                endDate?: string
+                endDate?: string,
             ) => listGamesByCohort(idToken, cohort, startKey, startDate, endDate),
             listGamesByOwner: (
                 owner?: string,
@@ -202,43 +202,28 @@ export function ApiProvider({ children }: { children: ReactNode }) {
                 startDate?: string,
                 endDate?: string,
                 player?: string,
-                color?: string
-            ) =>
-                listGamesByOwner(
-                    idToken,
-                    owner,
-                    startKey,
-                    startDate,
-                    endDate,
-                    player,
-                    color
-                ),
+                color?: string,
+            ) => listGamesByOwner(idToken, owner, startKey, startDate, endDate, player, color),
             listGamesByOpening: (
                 eco: string,
                 startKey?: string,
                 startDate?: string,
-                endDate?: string
+                endDate?: string,
             ) => listGamesByOpening(idToken, eco, startKey, startDate, endDate),
-            listFeaturedGames: (startKey?: string) =>
-                listFeaturedGames(idToken, startKey),
+            listFeaturedGames: (startKey?: string) => listFeaturedGames(idToken, startKey),
             createComment: (cohort: string, id: string, content: string) =>
                 createComment(idToken, auth.user!, cohort, id, content),
 
             getRequirement: (id: string) => getRequirement(idToken, id),
-            listRequirements: (
-                cohort: string,
-                scoreboardOnly: boolean,
-                startKey?: string
-            ) => listRequirements(idToken, cohort, scoreboardOnly, startKey),
-            setRequirement: (requirement: Requirement) =>
-                setRequirement(idToken, requirement),
+            listRequirements: (cohort: string, scoreboardOnly: boolean, startKey?: string) =>
+                listRequirements(idToken, cohort, scoreboardOnly, startKey),
+            setRequirement: (requirement: Requirement) => setRequirement(idToken, requirement),
 
             listGraduationsByCohort: (cohort: string, startKey?: string) =>
                 listGraduationsByCohort(idToken, cohort, startKey),
             listGraduationsByOwner: (username: string, startKey?: string) =>
                 listGraduationsByOwner(idToken, username, startKey),
-            listGraduationsByDate: (startKey?: string) =>
-                listGraduationsByDate(idToken, startKey),
+            listGraduationsByDate: (startKey?: string) => listGraduationsByDate(idToken, startKey),
 
             getCourse: (id: string) => getCourse(idToken, id),
             listCourses: (startKey?: string) => listCourses(idToken, startKey),
@@ -247,7 +232,7 @@ export function ApiProvider({ children }: { children: ReactNode }) {
                 timePeriod: TimePeriod,
                 tournamentType: TournamentType,
                 timeControl: TimeControl,
-                date: string
+                date: string,
             ) => getLeaderboard(timePeriod, tournamentType, timeControl, date),
 
             getOpenClassical: (startsAt?: string) => getOpenClassical(startsAt),
@@ -258,16 +243,12 @@ export function ApiProvider({ children }: { children: ReactNode }) {
             putOpenClassicalPairings: (round: number, pgnData: string) =>
                 putOpenClassicalPairings(idToken, round, pgnData),
 
-            listNotifications: (startKey?: string) =>
-                listNotifications(idToken, startKey),
+            listNotifications: (startKey?: string) => listNotifications(idToken, startKey),
             deleteNotification: (id: string) => deleteNotification(idToken, id),
 
-            getNewsfeedItem: (owner: string, id: string) => getNewsfeedItem(owner, id),
-            listNewsfeed: (
-                newsfeedIds: string[],
-                skipLastFetch?: boolean,
-                startKey?: string
-            ) => listNewsfeed(idToken, newsfeedIds, skipLastFetch, startKey),
+            getNewsfeedItem: (owner: string, id: string) => getNewsfeedItem(idToken, owner, id),
+            listNewsfeed: (newsfeedIds: string[], skipLastFetch?: boolean, startKey?: string) =>
+                listNewsfeed(idToken, newsfeedIds, skipLastFetch, startKey),
             createNewsfeedComment: (owner: string, id: string, content: string) =>
                 createNewsfeedComment(idToken, owner, id, content),
             setNewsfeedReaction: (owner: string, id: string, types: string[]) =>

--- a/mobile/src/api/newsfeedApi.tsx
+++ b/mobile/src/api/newsfeedApi.tsx
@@ -12,10 +12,7 @@ export type NewsfeedApiContextType = {
      * @param id The id of the timeline entry.
      * @returns An AxiosResponse containing the timeline entry.
      */
-    getNewsfeedItem: (
-        owner: string,
-        id: string
-    ) => Promise<AxiosResponse<TimelineEntry, any>>;
+    getNewsfeedItem: (owner: string, id: string) => Promise<AxiosResponse<TimelineEntry, any>>;
 
     /**
      * Fetches a page of the provided newsfeed.
@@ -27,7 +24,7 @@ export type NewsfeedApiContextType = {
     listNewsfeed: (
         newsfeedIds: string[],
         skipLastFetch?: boolean,
-        startKey?: string
+        startKey?: string,
     ) => Promise<AxiosResponse<ListNewsfeedResponse, any>>;
 
     /**
@@ -40,7 +37,7 @@ export type NewsfeedApiContextType = {
     createNewsfeedComment: (
         owner: string,
         id: string,
-        content: string
+        content: string,
     ) => Promise<AxiosResponse<TimelineEntry, any>>;
 
     /**
@@ -53,7 +50,7 @@ export type NewsfeedApiContextType = {
     setNewsfeedReaction: (
         owner: string,
         id: string,
-        types: string[]
+        types: string[],
     ) => Promise<AxiosResponse<TimelineEntry, any>>;
 };
 
@@ -63,8 +60,10 @@ export type NewsfeedApiContextType = {
  * @param id The id of the timeline entry.
  * @returns An AxiosResponse containing the timeline entry.
  */
-export function getNewsfeedItem(owner: string, id: string) {
-    return axios.get<TimelineEntry>(`${BASE_URL}/public/newsfeed/${owner}/${id}`);
+export function getNewsfeedItem(idToken: string, owner: string, id: string) {
+    return axios.get<TimelineEntry>(`${BASE_URL}/newsfeed/${owner}/${id}`, {
+        headers: { Authorization: 'Bearer ' + idToken },
+    });
 }
 
 /**
@@ -92,7 +91,7 @@ export function listNewsfeed(
     idToken: string,
     newsfeedIds: string[],
     skipLastFetch?: boolean,
-    startKey?: string
+    startKey?: string,
 ) {
     return axios.get<ListNewsfeedResponse>(`${BASE_URL}/newsfeed`, {
         params: {
@@ -114,12 +113,7 @@ export function listNewsfeed(
  * @param content The text content of the comment.
  * @returns The updated TimelineEntry.
  */
-export function createNewsfeedComment(
-    idToken: string,
-    owner: string,
-    id: string,
-    content: string
-) {
+export function createNewsfeedComment(idToken: string, owner: string, id: string, content: string) {
     return axios.post<TimelineEntry>(
         `${BASE_URL}/newsfeed/${owner}/${id}/comments`,
         { content },
@@ -127,7 +121,7 @@ export function createNewsfeedComment(
             headers: {
                 Authorization: 'Bearer ' + idToken,
             },
-        }
+        },
     );
 }
 
@@ -139,15 +133,10 @@ export function createNewsfeedComment(
  * @param types The reaction types to set. An empty list deletes the reaction.
  * @returns An AxiosResponse containing the updated TimelineEntry.
  */
-export function setNewsfeedReaction(
-    idToken: string,
-    owner: string,
-    id: string,
-    types: string[]
-) {
+export function setNewsfeedReaction(idToken: string, owner: string, id: string, types: string[]) {
     return axios.put<TimelineEntry>(
         `${BASE_URL}/newsfeed/${owner}/${id}/reactions`,
         { types },
-        { headers: { Authorization: 'Bearer ' + idToken } }
+        { headers: { Authorization: 'Bearer ' + idToken } },
     );
 }

--- a/mobile/src/api/userApi.ts
+++ b/mobile/src/api/userApi.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosResponse } from 'axios';
 
-import { User } from '../database/user';
 import { getConfig } from '@/config';
-import { Graduation } from '../database/graduation';
-import { TimelineEntry } from '../database/timeline';
-import { UserStatistics } from '../database/statistics';
 import { FollowerEntry } from '../database/follower';
+import { Graduation } from '../database/graduation';
+import { UserStatistics } from '../database/statistics';
+import { TimelineEntry } from '../database/timeline';
+import { User } from '../database/user';
 
 const BASE_URL = getConfig().api.baseUrl;
 
@@ -38,10 +38,7 @@ export type UserApiContextType = {
      * @param startKey The optional start key to use when searching.
      * @returns A ListUserTimelineResponse
      */
-    listUserTimeline: (
-        owner: string,
-        startKey?: string
-    ) => Promise<ListUserTimelineResponse>;
+    listUserTimeline: (owner: string, startKey?: string) => Promise<ListUserTimelineResponse>;
 
     /**
      * listUsersByCohort returns a list of users in the provided cohort.
@@ -68,7 +65,7 @@ export type UserApiContextType = {
      */
     updateUser: (
         update: Partial<User>,
-        autopickCohort?: boolean
+        autopickCohort?: boolean,
     ) => Promise<AxiosResponse<User, any>>;
 
     /**
@@ -85,7 +82,7 @@ export type UserApiContextType = {
         requirementId: string,
         incrementalCount: number,
         incrementalMinutesSpent: number,
-        date: Date | null
+        date: Date | null,
     ) => Promise<AxiosResponse<User, any>>;
 
     /**
@@ -104,7 +101,7 @@ export type UserApiContextType = {
         updated: TimelineEntry[],
         deleted: TimelineEntry[],
         count: number,
-        minutesSpent: number
+        minutesSpent: number,
     ) => Promise<AxiosResponse<User, any>>;
 
     /**
@@ -134,7 +131,7 @@ export type UserApiContextType = {
      */
     editFollower: (
         poster: string,
-        action: 'follow' | 'unfollow'
+        action: 'follow' | 'unfollow',
     ) => Promise<AxiosResponse<FollowerEntry | null, any>>;
 
     /**
@@ -145,7 +142,7 @@ export type UserApiContextType = {
      */
     listFollowers: (
         username: string,
-        startKey?: string
+        startKey?: string,
     ) => Promise<AxiosResponse<ListFollowersResponse, any>>;
 
     /**
@@ -156,7 +153,7 @@ export type UserApiContextType = {
      */
     listFollowing: (
         username: string,
-        startKey?: string
+        startKey?: string,
     ) => Promise<AxiosResponse<ListFollowersResponse, any>>;
 };
 
@@ -192,8 +189,10 @@ export function getUser(idToken: string) {
  * @param username The user to fetch public information for.
  * @returns An AxiosResponse containing the requested user.
  */
-export function getUserPublic(username: string) {
-    return axios.get<User>(BASE_URL + '/public/user/' + username);
+export function getUserPublic(idToken: string, username: string) {
+    return axios.get<User>(BASE_URL + '/user/profile/' + username, {
+        headers: { Authorization: 'Bearer ' + idToken },
+    });
 }
 
 export interface ListUserTimelineResponse {
@@ -208,21 +207,14 @@ export interface ListUserTimelineResponse {
  * @param startKey The optional start key to use when searching.
  * @returns A ListUserTimelineResponse
  */
-export async function listUserTimeline(
-    idToken: string,
-    owner: string,
-    startKey?: string
-) {
+export async function listUserTimeline(idToken: string, owner: string, startKey?: string) {
     let params = { startKey };
-    const resp = await axios.get<ListUserTimelineResponse>(
-        `${BASE_URL}/user/${owner}/timeline`,
-        {
-            params,
-            headers: {
-                Authorization: 'Bearer ' + idToken,
-            },
-        }
-    );
+    const resp = await axios.get<ListUserTimelineResponse>(`${BASE_URL}/user/${owner}/timeline`, {
+        params,
+        headers: {
+            Authorization: 'Bearer ' + idToken,
+        },
+    });
     return resp.data;
 }
 
@@ -238,11 +230,7 @@ interface ListUsersResponse {
  * @param startKey The optional startKey to use when searching.
  * @returns A list of users in the provided cohort.
  */
-export async function listUsersByCohort(
-    idToken: string,
-    cohort: string,
-    startKey?: string
-) {
+export async function listUsersByCohort(idToken: string, cohort: string, startKey?: string) {
     let params = { startKey };
     const result: User[] = [];
     do {
@@ -270,12 +258,9 @@ export async function searchUsers(query: string, fields: string[], startKey?: st
     const result: User[] = [];
 
     do {
-        const resp = await axios.get<ListUsersResponse>(
-            BASE_URL + '/public/user/search',
-            {
-                params,
-            }
-        );
+        const resp = await axios.get<ListUsersResponse>(BASE_URL + '/public/user/search', {
+            params,
+        });
         result.push(...resp.data.users);
         params.startKey = resp.data.lastEvaluatedKey;
     } while (params.startKey);
@@ -295,7 +280,7 @@ export async function updateUser(
     idToken: string,
     update: Partial<User>,
     callback: (update: Partial<User>) => void,
-    autopickCohort?: boolean
+    autopickCohort?: boolean,
 ) {
     const result = await axios.put<User>(`${BASE_URL}/user`, update, {
         headers: {
@@ -327,7 +312,7 @@ export async function updateUserProgress(
     incrementalCount: number,
     incrementalMinutesSpent: number,
     date: Date | null,
-    callback: (update: Partial<User>) => void
+    callback: (update: Partial<User>) => void,
 ) {
     const result = await axios.post<User>(
         BASE_URL + '/user/progress',
@@ -342,7 +327,7 @@ export async function updateUserProgress(
             headers: {
                 Authorization: 'Bearer ' + idToken,
             },
-        }
+        },
     );
     callback(result.data);
     return result;
@@ -368,7 +353,7 @@ export async function updateUserTimeline(
     deleted: TimelineEntry[],
     count: number,
     minutesSpent: number,
-    callback: (update: Partial<User>) => void
+    callback: (update: Partial<User>) => void,
 ) {
     const result = await axios.post<User>(
         BASE_URL + '/user/progress/timeline',
@@ -384,7 +369,7 @@ export async function updateUserTimeline(
             headers: {
                 Authorization: 'Bearer ' + idToken,
             },
-        }
+        },
     );
     callback(result.data);
     return result;
@@ -406,7 +391,7 @@ interface GraduationResponse {
 export async function graduate(
     idToken: string,
     comments: string,
-    callback: (update: Partial<User>) => void
+    callback: (update: Partial<User>) => void,
 ) {
     const result = await axios.post<GraduationResponse>(
         BASE_URL + '/user/graduate',
@@ -415,7 +400,7 @@ export async function graduate(
             headers: {
                 Authorization: 'Bearer ' + idToken,
             },
-        }
+        },
     );
     callback(result.data.userUpdate);
     return result;
@@ -449,11 +434,7 @@ export function getFollower(idToken: string, poster: string) {
  * @param action Whether to follow or unfollow the user.
  * @returns An empty AxiosResponse if successful.
  */
-export function editFollower(
-    idToken: string,
-    poster: string,
-    action: 'follow' | 'unfollow'
-) {
+export function editFollower(idToken: string, poster: string, action: 'follow' | 'unfollow') {
     return axios.post<FollowerEntry | null>(
         `${BASE_URL}/user/followers`,
         { poster, action },
@@ -461,7 +442,7 @@ export function editFollower(
             headers: {
                 Authorization: 'Bearer ' + idToken,
             },
-        }
+        },
     );
 }
 
@@ -477,10 +458,9 @@ export interface ListFollowersResponse {
  * @returns The list of followers and the next start key.
  */
 export function listFollowers(username: string, startKey?: string) {
-    return axios.get<ListFollowersResponse>(
-        `${BASE_URL}/public/user/${username}/followers`,
-        { params: { startKey } }
-    );
+    return axios.get<ListFollowersResponse>(`${BASE_URL}/public/user/${username}/followers`, {
+        params: { startKey },
+    });
 }
 
 /**
@@ -490,8 +470,7 @@ export function listFollowers(username: string, startKey?: string) {
  * @returns The list of who they are following and the next start key.
  */
 export function listFollowing(username: string, startKey?: string) {
-    return axios.get<ListFollowersResponse>(
-        `${BASE_URL}/public/user/${username}/following`,
-        { params: { startKey } }
-    );
+    return axios.get<ListFollowersResponse>(`${BASE_URL}/public/user/${username}/following`, {
+        params: { startKey },
+    });
 }


### PR DESCRIPTION
## Summary

Adds configurable training visibility with public, active Dojo member, mutual, and private audiences. Training data is
now redacted or filtered across profiles, activity feeds, scoreboards, clubs, graduations, and year reviews while
preserving basic profile information.

Users with non-public visibility can optionally share only their aggregate training time and Dojo points with everyone while keeping task-level activity and progress restricted to their selected audience.

## Related Issues

Fixes #2660

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
* [ ] Documentation update

## Testing

* [x] New unit tests (vitest) were added
* [ ] New playwright tests were added
* [ ] It was not necessary to add tests


## Demo

**Profile privacy setting**
<img width="1261" height="562" alt="image" src="https://github.com/user-attachments/assets/85730070-e76e-473d-9c69-bc7c3608e6e4" />

**Private profile notice**
<img width="313" height="367" alt="private profile notice" src="https://github.com/user-attachments/assets/921c5b52-cb67-40ec-99fc-7c85cc2f6da6" />