### PR TITLE
fix(frontend): stop a locale-prefixed URL from changing the reader's language

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -3,8 +3,8 @@ import path from 'path';
 
 const withNextIntl = createNextIntlPlugin();
 
-// Keep in sync with SUPPORTED_LOCALES in src/i18n/locales.ts and the regexes
-// in src/proxy.ts. When a new locale lands, extend the alternation here or
+// Keep in sync with SUPPORTED_LOCALES and LOCALE_PREFIX_REGEX in
+// src/i18n/locales.ts. When a new locale lands, extend the alternation here or
 // legacy redirects and video-embed COEP headers will silently stop matching
 // the new locale's URLs.
 const LOCALE_PATTERN = ':locale(en|pseudo|de|es|pt|fr|it)';

--- a/frontend/playwright/tests/e2e/i18n/routing.spec.ts
+++ b/frontend/playwright/tests/e2e/i18n/routing.spec.ts
@@ -1,4 +1,14 @@
-import { expect, test } from '@playwright/test';
+import { Browser, BrowserContext, expect, test } from '@playwright/test';
+
+/** A cookie-less English-browser context, so only the URL can pick the locale. */
+async function newEnglishContext(browser: Browser): Promise<BrowserContext> {
+    return browser.newContext({ locale: 'en-US', storageState: { cookies: [], origins: [] } });
+}
+
+/** The stored locale preference, if any. */
+async function localeCookie(context: BrowserContext): Promise<string | undefined> {
+    return (await context.cookies()).find((c) => c.name === 'locale')?.value;
+}
 
 test.describe('localePrefix: as-needed - unauthenticated', () => {
     // Run these routing tests without auth so bare-URL redirects are not
@@ -71,6 +81,67 @@ test.describe('localePrefix: as-needed - unauthenticated', () => {
     });
 });
 
+test.describe('localePrefix: as-needed - locale cookie', () => {
+    // A prefixed URL must not store a preference. Assert on cookies and URLs,
+    // never on rendered text. All bundles ship to the client and translation
+    // happens after hydration, so SSR HTML for /de differs from /en only by
+    // lang and a token.
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test('visiting a prefixed URL stores nothing', async ({ browser }) => {
+        const context = await newEnglishContext(browser);
+        const page = await context.newPage();
+        await page.goto('/de/prices');
+        expect(await localeCookie(context)).toBeUndefined();
+        await context.close();
+    });
+
+    test('a bare URL after a prefixed visit stays bare', async ({ browser }) => {
+        const context = await newEnglishContext(browser);
+        const page = await context.newPage();
+        await page.goto('/de/prices');
+        await page.goto('/prices');
+        // A /\/prices$/ regex would also accept /de/prices. The string is an exact match.
+        await expect(page).toHaveURL('/prices');
+        await context.close();
+    });
+
+    test('a stored preference still routes bare URLs', async ({ browser }) => {
+        const context = await newEnglishContext(browser);
+        await context.addCookies([{ name: 'locale', value: 'de', domain: 'localhost', path: '/' }]);
+        const page = await context.newPage();
+        await page.goto('/prices');
+        await expect(page).toHaveURL('/de/prices');
+        await context.close();
+    });
+
+    // Three different exits from proxy.ts: next-intl redirects the uppercase
+    // prefix, the auth check redirects the unknown path, /pseudo is served as is.
+    for (const path of ['/DE/prices', '/de/zzz-nonexistent-page', '/pseudo/prices']) {
+        test(`${path} stores nothing`, async ({ browser }) => {
+            const context = await newEnglishContext(browser);
+            const page = await context.newPage();
+            await page.goto(path);
+            expect(await localeCookie(context)).toBeUndefined();
+            await context.close();
+        });
+    }
+
+    test('a request without Sec-Fetch-Dest stores nothing', async ({ browser }) => {
+        // next-intl skips the cookie write when Sec-Fetch-Dest is present and not
+        // "document", so browser prefetches never reach it. A client or CDN hop
+        // without the header does.
+        const context = await newEnglishContext(browser);
+        const response = await context.request.get('/de/prices', {
+            headers: { RSC: '1' },
+            maxRedirects: 0,
+        });
+        const setCookie = response.headersArray().filter((h) => /^set-cookie$/i.test(h.name));
+        expect(setCookie.filter((h) => h.value.startsWith('locale='))).toEqual([]);
+        await context.close();
+    });
+});
+
 test.describe('localePrefix: as-needed - authenticated', () => {
     // Uses the default storageState from playwright.config.ts (authenticated).
 
@@ -86,5 +157,20 @@ test.describe('localePrefix: as-needed - authenticated', () => {
         // by the proxy, so this test must run authenticated.
         const response = await page.goto('/zz/profile');
         expect(response?.status()).toBe(404);
+    });
+
+    test('RequireProfile moves a prefixed URL to the profile language', async ({
+        page,
+        context,
+    }) => {
+        // RequireProfile writes the profile language (unset means English) to the
+        // cookie. Read it, then visit a prefix that differs from it, so the
+        // correction has to happen whatever the test account's setting is.
+        await page.goto('/profile');
+        await expect.poll(() => localeCookie(context)).toBeDefined();
+        const preferred = (await localeCookie(context)) ?? 'en';
+        const other = preferred === 'de' ? 'pseudo' : 'de';
+        await page.goto(`/${other}/profile`);
+        await expect(page).toHaveURL(preferred === 'en' ? '/profile' : `/${preferred}/profile`);
     });
 });

--- a/frontend/src/board/pgn/boardTools/boardButtons/StartButtons.tsx
+++ b/frontend/src/board/pgn/boardTools/boardButtons/StartButtons.tsx
@@ -1,3 +1,4 @@
+import { stripLocalePrefixFromUrl } from '@/i18n/locales';
 import { Check, ContentPaste } from '@mui/icons-material';
 import { IconButton, Menu, MenuItem, Stack, Tooltip } from '@mui/material';
 import { useTranslations } from 'next-intl';
@@ -33,7 +34,7 @@ const StartButtons = () => {
         if (fen) {
             url.searchParams.set('fen', fen);
         }
-        await navigator.clipboard.writeText(url.href);
+        await navigator.clipboard.writeText(stripLocalePrefixFromUrl(url.href));
         onCopy('url');
     };
 

--- a/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
+++ b/frontend/src/board/pgn/boardTools/underboard/share/ShareTab.tsx
@@ -10,6 +10,7 @@ import { DirectoryCacheProvider } from '@/components/profile/directories/Directo
 import { getConfig } from '@/config';
 import useGame from '@/context/useGame';
 import { pgnExportOptions, usePgnExportOptions } from '@/hooks/usePgnExportOptions';
+import { stripLocalePrefixFromUrl } from '@/i18n/locales';
 import { Chess } from '@jackstenglein/chess';
 import { GameImportTypes } from '@jackstenglein/chess-dojo-common/src/database/game';
 import { PdfExportRequest } from '@jackstenglein/chess-dojo-common/src/pgn/export';
@@ -139,7 +140,7 @@ export function ShareTab() {
     };
 
     const onCopyUrl = () => {
-        void onCopy('url', window.location.href);
+        void onCopy('url', stripLocalePrefixFromUrl(window.location.href));
     };
 
     const onCopyFen = () => {
@@ -159,7 +160,7 @@ export function ShareTab() {
             black: getPlayer(chess, 'Black', 'BlackElo'),
             date: chess.header().getRawValue('Date'),
             lastMove: board?.state.lastMove?.join('') || '',
-            comment: window.location.href,
+            comment: stripLocalePrefixFromUrl(window.location.href),
             theme: boardStyle.toLowerCase(),
             piece:
                 pieceStyle === PieceStyle.ThreeD || pieceStyle === PieceStyle.ThreeDRedBlue
@@ -187,7 +188,7 @@ export function ShareTab() {
             black,
             date: chess.header().getRawValue('Date'),
             orientation: board?.state.orientation || 'white',
-            comment: window.location.href,
+            comment: stripLocalePrefixFromUrl(window.location.href),
             theme: boardStyle.toLowerCase(),
             piece:
                 pieceStyle === PieceStyle.ThreeD || pieceStyle === PieceStyle.ThreeDRedBlue
@@ -313,7 +314,7 @@ export function ShareTab() {
         }
 
         cloneRequest.onStart();
-        chess.setHeader('ClonedFrom', window.location.href);
+        chess.setHeader('ClonedFrom', stripLocalePrefixFromUrl(window.location.href));
         const pgn = renderPgn();
         chess.setHeader('ClonedFrom');
 

--- a/frontend/src/components/auth/RequireProfile.tsx
+++ b/frontend/src/components/auth/RequireProfile.tsx
@@ -40,30 +40,27 @@ export function RequireProfile() {
         }
     }, [request, api, status, updateUser, user]);
 
+    const username = user?.username;
+    const language = user?.language;
+
     useEffect(() => {
-        const preferred = user?.language;
-        if (!preferred) return;
-        // Persist the cross-device preference into the cookie so the
-        // middleware picks it up on bare-URL visits. setLocaleCookie silently
-        // no-ops on an unsupported value, and the guard below also gates the
-        // URL redirect - a stale user.language outside SUPPORTED_LOCALES
-        // leaves both untouched rather than corrupting state.
+        if (!username) return;
+
+        // Unset means English (common/src/database/user.ts).
+        const preferred = language || DEFAULT_LOCALE;
+        if (!(LOCALE_CODES as readonly string[]).includes(preferred)) return;
+
         setLocaleCookie(preferred);
-        if (
-            preferred !== currentLocale &&
-            (LOCALE_CODES as readonly string[]).includes(preferred)
-        ) {
-            // next-intl 4.x: passing { locale } always emits a prefixed URL
-            // even under as-needed (to let the cookie write before hydration).
-            // For the default locale we drop the option and rely on the cookie
-            // set above, so the URL lands at the bare path instead of /en/...
-            if (preferred === DEFAULT_LOCALE) {
-                router.replace(pathname);
-            } else {
-                router.replace(pathname, { locale: preferred });
-            }
+
+        // A hard navigation, as the profile editor does on a language change.
+        // next-intl's replace with { locale: 'en' } emits /en/..., and the 308
+        // back to the bare path drops the hash. usePathname() has no query or hash.
+        if (preferred !== currentLocale) {
+            const { search, hash } = window.location;
+            const prefix = preferred === DEFAULT_LOCALE ? '' : `/${preferred}`;
+            window.location.replace(`${prefix}${pathname}${search}${hash}`);
         }
-    }, [user?.language, currentLocale, router, pathname]);
+    }, [username, language, currentLocale, pathname]);
 
     useEffect(() => {
         if (user && !hasCreatedProfile(user) && !validPathnames.includes(pathname)) {

--- a/frontend/src/i18n/locales.test.ts
+++ b/frontend/src/i18n/locales.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { stripLocalePrefixFromUrl } from './locales';
+
+describe('stripLocalePrefixFromUrl', () => {
+    it('removes a non-default locale prefix', () => {
+        expect(stripLocalePrefixFromUrl('https://www.chessdojo.club/de/games/1500-1600/abc')).toBe(
+            'https://www.chessdojo.club/games/1500-1600/abc',
+        );
+        expect(stripLocalePrefixFromUrl('https://www.chessdojo.club/pseudo/prices')).toBe(
+            'https://www.chessdojo.club/prices',
+        );
+    });
+
+    it('leaves a bare URL unchanged', () => {
+        expect(stripLocalePrefixFromUrl('https://www.chessdojo.club/games/1500-1600/abc')).toBe(
+            'https://www.chessdojo.club/games/1500-1600/abc',
+        );
+    });
+
+    it('keeps the query string and fragment', () => {
+        expect(
+            stripLocalePrefixFromUrl('https://www.chessdojo.club/de/games/x?fen=abc#comment'),
+        ).toBe('https://www.chessdojo.club/games/x?fen=abc#comment');
+    });
+
+    it('collapses to / when the path is only a locale', () => {
+        expect(stripLocalePrefixFromUrl('https://www.chessdojo.club/de')).toBe(
+            'https://www.chessdojo.club/',
+        );
+    });
+
+    it('does not strip a path segment that starts with a locale code', () => {
+        // '/design' begins with 'de' but is not the de locale.
+        expect(stripLocalePrefixFromUrl('https://www.chessdojo.club/design')).toBe(
+            'https://www.chessdojo.club/design',
+        );
+    });
+});

--- a/frontend/src/i18n/locales.ts
+++ b/frontend/src/i18n/locales.ts
@@ -14,7 +14,20 @@ export const DEFAULT_LOCALE = 'en';
 
 export const LOCALE_CODES = SUPPORTED_LOCALES.map((l) => l.code) as readonly LocaleCode[];
 
+export const LOCALE_PREFIX_REGEX = new RegExp(`^/(${LOCALE_CODES.join('|')})(?=/|$)`);
+
+/** Strips the locale prefix from an absolute URL. Copied links must not carry the reader's language. */
+export function stripLocalePrefixFromUrl(href: string): string {
+    const url = new URL(href);
+    url.pathname = url.pathname.replace(LOCALE_PREFIX_REGEX, '');
+    return url.href;
+}
+
+export const LOCALE_COOKIE_NAME = 'locale';
+
+/** Stores the chosen locale. The middleware reads it on bare-URL visits. The server never writes it. */
 export function setLocaleCookie(locale: string) {
     if (!(LOCALE_CODES as readonly string[]).includes(locale)) return;
-    document.cookie = `locale=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax`;
+    const secure = window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${LOCALE_COOKIE_NAME}=${locale}; path=/; max-age=${60 * 60 * 24 * 365}; SameSite=Lax${secure}`;
 }

--- a/frontend/src/i18n/routing.ts
+++ b/frontend/src/i18n/routing.ts
@@ -1,13 +1,14 @@
 import { defineRouting } from 'next-intl/routing';
-import { DEFAULT_LOCALE, LOCALE_CODES } from './locales';
+import { DEFAULT_LOCALE, LOCALE_CODES, LOCALE_COOKIE_NAME } from './locales';
 
 export const routing = defineRouting({
     locales: LOCALE_CODES,
     defaultLocale: DEFAULT_LOCALE,
     localePrefix: 'as-needed',
     localeDetection: true,
+    // Read by next-intl on bare-URL visits. proxy.ts drops next-intl's own write.
     localeCookie: {
-        name: 'locale',
+        name: LOCALE_COOKIE_NAME,
         maxAge: 60 * 60 * 24 * 365,
         sameSite: 'lax',
         secure: process.env.NODE_ENV === 'production',

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -2,19 +2,11 @@ import { runWithAmplifyServerContext } from '@/auth/amplifyServerUtils';
 import { fetchAuthSession } from 'aws-amplify/auth/server';
 import createIntlMiddleware from 'next-intl/middleware';
 import { NextRequest, NextResponse } from 'next/server';
-import { DEFAULT_LOCALE, LOCALE_CODES } from './i18n/locales';
+import { DEFAULT_LOCALE, LOCALE_PREFIX_REGEX } from './i18n/locales';
 import { routing } from './i18n/routing';
 import { logger } from './logging/logger';
 
 const intlMiddleware = createIntlMiddleware(routing);
-
-// Derived from LOCALE_CODES so adding a locale in locales.ts covers every
-// matcher site. A hard-coded alternation here would silently strip new
-// locales and emit wrong-prefix redirects.
-if (LOCALE_CODES.length === 0) {
-    throw new Error('proxy: LOCALE_CODES is empty; SUPPORTED_LOCALES must have at least one entry');
-}
-const LOCALE_PREFIX_REGEX = new RegExp(`^/(${LOCALE_CODES.join('|')})(?=/|$)`);
 
 // Under localePrefix: 'as-needed', the default locale is served at bare URLs
 // (e.g. '/profile' for en). Non-default locales keep their prefix
@@ -83,14 +75,13 @@ const legacyRoutes = [
 ];
 
 export async function proxy(request: NextRequest) {
-    // Run next-intl first. For non-default locales it returns a redirect
-    // (Location header); for the default locale under as-needed it returns
-    // a rewrite (x-middleware-rewrite) with no Location. If it's a redirect,
-    // short-circuit now. Otherwise fall through and forward its rewrite +
-    // cookie headers onto whatever the auth/legacy logic decides to return.
+    // next-intl answers a non-default locale with a redirect and the default
+    // locale with a rewrite. The rewrite is forwarded onto whatever we return.
     let intlResponse: NextResponse | undefined;
     try {
         intlResponse = intlMiddleware(request);
+        // Drop next-intl's Set-Cookie, or a prefixed URL becomes a stored preference.
+        intlResponse.headers.delete('set-cookie');
     } catch (error) {
         logger.error?.('next-intl middleware threw; falling through', error);
     }
@@ -98,31 +89,14 @@ export async function proxy(request: NextRequest) {
         return intlResponse;
     }
 
-    // Under as-needed, next-intl rewrites bare default-locale URLs internally
-    // via x-middleware-rewrite (no Location header) and sets a Set-Cookie on
-    // first visits. We must forward both onto our own response or Next will
-    // 404 the bare URL (no [locale] segment match) and the locale cookie will
-    // be lost forever. getSetCookie() returns each cookie separately; fall
-    // back to get('set-cookie') for runtimes that don't expose it.
+    // Forward next-intl's rewrite header, or Next 404s the bare default-locale URL.
     function forwardIntlHeaders(target: NextResponse): NextResponse {
         if (!intlResponse) return target;
         const headers = intlResponse.headers;
         const rewrite = headers.get('x-middleware-rewrite');
-        // x-middleware-rewrite is meaningless on a redirect response and Next
-        // currently ignores it there, but a future version honouring it would
-        // double-rewrite. Gate to pass-through responses only.
+        // Not on redirects: a future Next honouring the header there would double-rewrite.
         if (rewrite && !target.headers.get('location')) {
             target.headers.set('x-middleware-rewrite', rewrite);
-        }
-
-        const cookies = typeof headers.getSetCookie === 'function' ? headers.getSetCookie() : [];
-        if (cookies.length > 0) {
-            for (const cookie of cookies) {
-                target.headers.append('set-cookie', cookie);
-            }
-        } else {
-            const single = headers.get('set-cookie');
-            if (single) target.headers.append('set-cookie', single);
         }
         return target;
     }


### PR DESCRIPTION
## Summary

Opening a link with a locale prefix, such as `/de/...` or `/es/...`, switched the reader's language to that locale for a year. next-intl's middleware stores whatever locale it resolved, and the URL prefix wins over the cookie, so one shared link to a translated page was enough. The middleware cannot tell a language switch from a click on a shared link. A member whose profile language is unset never got corrected, because `RequireProfile` only acted on an explicit language.

Changes:

- `proxy.ts` drops next-intl's `Set-Cookie`. The middleware still reads the cookie to route bare URLs. The server never writes it.
- Only the client writes the cookie, and only from a deliberate act. The profile editor writes it on a language change, as before. `RequireProfile` writes the profile language after sign-in, with unset meaning English.
- `RequireProfile` moves a prefixed URL to the profile language with a full page load, keeping the query and hash. A signed-in English member who opens `/de/profile` lands on `/profile`.
- The share tab and the copy-URL button strip the locale prefix, so a copied link carries the page and not the reader's language.
- The cookie name and the locale prefix regex live in `i18n/locales.ts`. `setLocaleCookie` sets `Secure` on https.

## Related Issues

Fixes #2431

The issue is closed as not reproducible. To reproduce on `dev`:

1. In a browser with no cookies for the site, open `/de/prices`. DevTools now shows a `locale=de` cookie with a one-year expiry.
2. Open `/prices`. The middleware redirects to `/de/prices`.
3. Sign in as a member whose profile language is unset. Every page stays German. Clearing site data is the only way out, which matches the finding that a fresh profile could not reproduce it.

After this change, step 1 sets no cookie, step 2 stays on /prices, and the member in step 3 lands on /profile on the first page load after sign-in.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* [x] New unit tests (vitest) were added
* [x] New playwright tests were added


`i18n/locales.test.ts` covers `stripLocalePrefixFromUrl`. `playwright/tests/e2e/i18n/routing.spec.ts` adds a `locale cookie` group: a prefixed visit stores nothing, a bare URL after a prefixed visit stays bare, a stored preference still routes bare URLs, the uppercase, unknown-path, and `/pseudo` prefixes store nothing, and a request without `Sec-Fetch-Dest` stores nothing. The authenticated group gains a case where `RequireProfile` moves a prefixed URL to the profile language. The tests assert on cookies, status codes, and URLs, never on rendered text, because every locale bundle ships to the client and SSR HTML for `/de` differs from `/en` only by `lang` and a token.

Run on this branch: `tsc`, `eslint`, vitest (69 passed), and `pnpm test:playwright e2e/i18n` against a production build (19 passed, 1 pre-existing skip). Also checked by hand on `pnpm dev` through an intercepting proxy: no response on the site carries `Set-Cookie`, `/de/profile` corrects to `/profile` for an English profile, and `/prices` no longer redirects after a prefixed visit.

## Demo

No visual change.