### PR TITLE
fix(frontend): three board-stack fixes behind the solitaire engine

### DIFF
--- a/frontend/playwright/tests/e2e/material/memorizeGames.spec.ts
+++ b/frontend/playwright/tests/e2e/material/memorizeGames.spec.ts
@@ -23,6 +23,33 @@ test.describe('Memorize Games Page', () => {
         await expect(page.getByText('Show Answer')).toBeVisible();
     });
 
+    test('should not reveal moves past the frontier via keyboard in test mode', async ({
+        page,
+    }) => {
+        // window.d.ts imports chessground's Api from a package that is not installed.
+        const getFen = () =>
+            page.evaluate(() =>
+                (window as unknown as { chessground: { getFen(): string } }).chessground.getFen(),
+            );
+        const startFen = await getFen();
+
+        // Study mode first, to show the key reaches the board at all.
+        await page.keyboard.press('ArrowRight');
+        expect(await getFen()).not.toBe(startFen);
+        await page.keyboard.press('ArrowLeft');
+        expect(await getFen()).toBe(startFen);
+
+        await page.getByRole('radio', { name: 'Test' }).click();
+        await expect(page.getByText('Show Answer')).toBeVisible();
+
+        // First variation falls back to the next mainline move.
+        await page.keyboard.press('Shift+ArrowRight');
+        expect(await getFen()).toBe(startFen);
+
+        await page.keyboard.press('ArrowRight');
+        expect(await getFen()).toBe(startFen);
+    });
+
     test('should switch between games', async ({ page }) => {
         // Click different games from the PGN selector
         const items = page.getByTestId('pgn-selector-item');

--- a/frontend/src/board/Board.tsx
+++ b/frontend/src/board/Board.tsx
@@ -275,7 +275,9 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
     const { chess, config: chessConfig } = useChess();
     const [board, setBoard] = useState<BoardApi | null>(null);
     const boardRef = useRef<HTMLDivElement>(null);
-    const [isInitialized, setIsInitialized] = useState(false);
+    // Last initialized key, fen and pgn. A ref rather than state, so a changed
+    // position re-initializes in the same commit, before parent effects redraw.
+    const initialized = useRef<{ initKey?: string; fen?: string; pgn?: string } | null>(null);
     const [promotion, setPromotion] = useState<PrePromotionMove | null>(null);
     const [boardStyle] = useLocalStorage<BoardStyle>(BoardStyleKey, BoardStyle.Standard);
     const [pieceStyle] = useLocalStorage<PieceStyle>(PieceStyleKey, PieceStyle.Standard);
@@ -319,12 +321,22 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
         reconcile(chess, board, showGlyphs, playSound);
     }, [board, chess, showGlyphs, playSound]);
 
+    const fen = config?.fen;
+    const pgn = config?.pgn;
+    const initKey = chessConfig?.initKey;
+
     useEffect(() => {
+        const needsInit =
+            !initialized.current ||
+            initialized.current.initKey !== initKey ||
+            initialized.current.fen !== fen ||
+            initialized.current.pgn !== pgn;
+
         if (boardRef.current && !board) {
             const chessgroundApi = Chessground(boardRef.current, config);
             setBoard(chessgroundApi);
             window.chessground = chessgroundApi;
-        } else if (boardRef.current && board && chess && !isInitialized) {
+        } else if (boardRef.current && board && chess && needsInit) {
             if (config?.pgn) {
                 chess.loadPgn(config.pgn);
                 chess.seek(null);
@@ -370,19 +382,20 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
             onInitialize?.(board, chess, boardRef);
             // onInitialize may load a position too, so re-enable animation after it.
             board.set({ animation: { enabled: true, ...config?.animation } });
-            setIsInitialized(true);
-        } else if (boardRef.current && board && !isInitialized) {
+            initialized.current = { initKey, fen, pgn };
+        } else if (boardRef.current && board && needsInit) {
             board.set({ ...config });
             onInitializeBoard?.(board);
-            setIsInitialized(true);
+            initialized.current = { initKey, fen, pgn };
         }
     }, [
         boardRef,
         board,
         chess,
         config,
-        isInitialized,
-        setIsInitialized,
+        initKey,
+        fen,
+        pgn,
         onMove,
         onInitialize,
         onInitializeBoard,
@@ -391,15 +404,6 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
         showGlyphs,
         playSound,
     ]);
-
-    const fen = config?.fen;
-    const pgn = config?.pgn;
-    const initKey = chessConfig?.initKey;
-    useEffect(() => {
-        if (initKey || fen || pgn) {
-            setIsInitialized(false);
-        }
-    }, [initKey, fen, pgn, setIsInitialized]);
 
     useEffect(() => {
         if (chess && board) {

--- a/frontend/src/board/Board.tsx
+++ b/frontend/src/board/Board.tsx
@@ -334,6 +334,9 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
 
             board.set({
                 ...config,
+                // Loading a position must not animate, or the pieces fly in from
+                // the default position or from the previous one.
+                animation: { enabled: false },
                 fen: chess.fen(),
                 turnColor: config?.turnColor || toColor(chess),
                 movable: {
@@ -365,6 +368,8 @@ const Board: React.FC<BoardProps> = ({ config, onInitialize, onInitializeBoard, 
             });
 
             onInitialize?.(board, chess, boardRef);
+            // onInitialize may load a position too, so re-enable animation after it.
+            board.set({ animation: { enabled: true, ...config?.animation } });
             setIsInitialized(true);
         } else if (boardRef.current && board && !isInitialized) {
             board.set({ ...config });

--- a/frontend/src/board/pgn/KeyboardHandler.tsx
+++ b/frontend/src/board/pgn/KeyboardHandler.tsx
@@ -17,6 +17,7 @@ import {
     VariationBehavior,
     VariationBehaviorKey,
 } from './boardTools/underboard/settings/ViewerSettings';
+import { solitaireBlocksAction } from './solitaire/solitaireFrontier';
 
 const SCROLL_THROTTLE_DELAY = 250; // milliseconds
 
@@ -94,12 +95,7 @@ const KeyboardHandler: React.FC<KeyboardHandlerProps> = ({ underboardRef }) => {
                 }
             }
 
-            if (
-                matchedAction === ShortcutAction.NextMove &&
-                solitaire?.enabled &&
-                !solitaire.complete &&
-                chess.currentMove() === solitaire.currentMove
-            ) {
+            if (solitaireBlocksAction(matchedAction, chess, solitaire)) {
                 return;
             }
 
@@ -166,17 +162,13 @@ const KeyboardHandler: React.FC<KeyboardHandlerProps> = ({ underboardRef }) => {
             if (!timeoutId) {
                 timeoutId = setTimeout(
                     () => {
+                        timeoutId = null;
                         const action =
                             event.deltaY < 0
                                 ? ShortcutAction.PreviousMove
                                 : ShortcutAction.NextMove;
 
-                        if (
-                            action === ShortcutAction.NextMove &&
-                            solitaire?.enabled &&
-                            !solitaire.complete &&
-                            chess.currentMove() === solitaire.currentMove
-                        ) {
+                        if (solitaireBlocksAction(action, chess, solitaire)) {
                             return;
                         }
 
@@ -186,7 +178,6 @@ const KeyboardHandler: React.FC<KeyboardHandlerProps> = ({ underboardRef }) => {
                             reconcile,
                         });
                         lastExecTime = Date.now();
-                        timeoutId = null;
                     },
                     Math.max(1, SCROLL_THROTTLE_DELAY - timeSinceLastExec),
                 );

--- a/frontend/src/board/pgn/PgnBoard.test.tsx
+++ b/frontend/src/board/pgn/PgnBoard.test.tsx
@@ -1,0 +1,177 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import PgnBoard from './PgnBoard';
+
+interface FakeCall {
+    type: 'set' | 'toggle';
+    fen?: string;
+    orientation: string;
+    animationEnabled?: boolean;
+}
+
+const fake = vi.hoisted(() => {
+    const calls: FakeCall[] = [];
+    const state = { orientation: 'white', animation: { enabled: true, duration: 200 } };
+    const api = {
+        state,
+        set: vi.fn(
+            (config: { fen?: string; orientation?: string; animation?: { enabled?: boolean } }) => {
+                if (config.orientation && config.orientation !== state.orientation) {
+                    state.orientation = config.orientation;
+                }
+                if (config.animation?.enabled !== undefined) {
+                    state.animation.enabled = config.animation.enabled;
+                }
+                calls.push({
+                    type: 'set',
+                    fen: config.fen,
+                    orientation: state.orientation,
+                    animationEnabled: state.animation.enabled,
+                });
+            },
+        ),
+        toggleOrientation: vi.fn(() => {
+            state.orientation = state.orientation === 'white' ? 'black' : 'white';
+            calls.push({ type: 'toggle', orientation: state.orientation });
+        }),
+        redrawAll: vi.fn(),
+        destroy: vi.fn(),
+        getFen: vi.fn(() => ''),
+        setShapes: vi.fn(),
+        setAutoShapes: vi.fn(),
+        cancelMove: vi.fn(),
+        stop: vi.fn(),
+    };
+    return { calls, state, api };
+});
+
+vi.mock('@lichess-org/chessground', () => ({
+    Chessground: (_el: HTMLElement, config?: { orientation?: string }) => {
+        if (config?.orientation) {
+            fake.state.orientation = config.orientation;
+        }
+        return fake.api;
+    },
+}));
+
+vi.mock('@/style/useWindowSizeEffect', () => ({
+    useWindowSizeEffect: () => undefined,
+}));
+vi.mock('@/auth/Auth', () => ({
+    useAuth: () => ({ user: undefined }),
+}));
+vi.mock('@/api/Api', () => ({
+    useApi: () => ({}),
+}));
+vi.mock('@/api/Request', () => ({
+    useRequest: () => ({
+        onStart: vi.fn(),
+        onSuccess: vi.fn(),
+        onFailure: vi.fn(),
+        reset: vi.fn(),
+        isLoading: () => false,
+        isSent: () => false,
+        isFailure: () => false,
+    }),
+    RequestSnackbar: () => null,
+}));
+vi.mock('@/loading/LoadingPage', () => ({
+    default: () => null,
+}));
+vi.mock('@/board/sounds/useBoardSound', () => ({
+    useBoardSound: () => ({ playSound: vi.fn() }),
+}));
+vi.mock('next-intl', () => ({
+    useTranslations: () => (key: string) => key,
+}));
+vi.mock('next-navigation-guard', () => ({
+    useNavigationGuard: () => ({ active: false, accept: vi.fn(), reject: vi.fn() }),
+}));
+vi.mock('./KeyboardHandler', () => ({
+    default: () => null,
+}));
+vi.mock('./pgnText/PgnText', () => ({
+    PgnTextBanners: () => null,
+    ResizablePgnText: () => null,
+}));
+vi.mock('./boardTools/underboard/Underboard', () => ({
+    default: () => null,
+}));
+// The board area and Board stay real; everything around them is mocked.
+vi.mock('./PlayerHeader', () => ({
+    default: () => null,
+}));
+vi.mock('./boardTools/boardButtons/BoardButtons', () => ({
+    default: () => null,
+}));
+
+const PGN_A = '[FEN "8/8/8/8/8/8/8/K6k w - - 0 1"]\n[SetUp "1"]\n\n*';
+const PGN_B = '[FEN "k7/8/8/8/8/8/8/6K1 b - - 0 1"]\n[SetUp "1"]\n\n*';
+
+const placement = (fen?: string) => fen?.split(' ')[0];
+
+describe('PgnBoard (re)initialization', () => {
+    beforeEach(() => {
+        fake.calls.length = 0;
+        fake.state.orientation = 'white';
+        fake.state.animation.enabled = true;
+        Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+            configurable: true,
+            value: () => ({ width: 1200, height: 800, top: 0, left: 0, right: 1200, bottom: 800 }),
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('applies a new position and orientation in one set, without a separate toggle', () => {
+        const { rerender } = render(
+            <div id='resize-container'>
+                <PgnBoard pgn={PGN_A} startOrientation='black' underboardTabs={[]} />
+            </div>,
+        );
+
+        const initA = fake.calls.find((c) => c.type === 'set' && c.fen);
+        expect(initA).toBeDefined();
+        expect(placement(initA?.fen)).toBe('8/8/8/8/8/8/8/K6k');
+        expect(initA?.orientation).toBe('black');
+        expect(initA?.animationEnabled).toBe(false);
+        expect(fake.calls.filter((c) => c.type === 'toggle')).toHaveLength(0);
+        expect(fake.state.animation.enabled).toBe(true);
+
+        const before = fake.calls.length;
+        rerender(
+            <div id='resize-container'>
+                <PgnBoard pgn={PGN_B} startOrientation='white' underboardTabs={[]} />
+            </div>,
+        );
+        const after = fake.calls.slice(before);
+
+        // A toggle before the set would show the old position flipped for a frame.
+        expect(after[0]?.type).toBe('set');
+        expect(placement(after[0]?.fen)).toBe('k7/8/8/8/8/8/8/6K1');
+        expect(after[0]?.orientation).toBe('white');
+        expect(after[0]?.animationEnabled).toBe(false);
+        expect(after.filter((c) => c.type === 'toggle')).toHaveLength(0);
+        expect(fake.state.animation.enabled).toBe(true);
+    });
+
+    it('flips the board without reloading the position when only the orientation changes', () => {
+        const { rerender } = render(
+            <div id='resize-container'>
+                <PgnBoard pgn={PGN_A} startOrientation='white' underboardTabs={[]} />
+            </div>,
+        );
+        const before = fake.calls.length;
+        rerender(
+            <div id='resize-container'>
+                <PgnBoard pgn={PGN_A} startOrientation='black' underboardTabs={[]} />
+            </div>,
+        );
+        const after = fake.calls.slice(before);
+        expect(after.filter((c) => c.type === 'toggle')).toHaveLength(1);
+        expect(after.filter((c) => c.type === 'set' && c.fen)).toHaveLength(0);
+        expect(fake.state.orientation).toBe('black');
+    });
+});

--- a/frontend/src/board/pgn/PgnBoard.tsx
+++ b/frontend/src/board/pgn/PgnBoard.tsx
@@ -290,13 +290,15 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
             [parentOnInitialize, setBoard],
         );
 
+        // Board applies gameOrientation when it (re)initializes. This syncs the
+        // context and handles an orientation change without a position change.
         const gameOrientation = game?.orientation || startOrientation || 'white';
         useEffect(() => {
-            if (gameOrientation !== board?.state.orientation) {
-                setOrientation(gameOrientation);
-                toggleOrientation();
+            setOrientation(gameOrientation);
+            if (board && gameOrientation !== board.state.orientation) {
+                board.toggleOrientation();
             }
-        }, [gameOrientation, board, toggleOrientation]);
+        }, [gameOrientation, board]);
 
         useEffect(() => {
             // eslint-disable-next-line react-hooks/immutability
@@ -376,7 +378,7 @@ const PgnBoard = forwardRef<PgnBoardApi, PgnBoardProps>(
                                     showPlayerHeaders,
                                     pgn,
                                     fen,
-                                    startOrientation,
+                                    startOrientation: gameOrientation,
                                     onInitialize,
                                 }}
                             />

--- a/frontend/src/board/pgn/boardTools/boardButtons/ControlButtons.tsx
+++ b/frontend/src/board/pgn/boardTools/boardButtons/ControlButtons.tsx
@@ -11,6 +11,8 @@ import { useTranslations } from 'next-intl';
 import { useLocalStorage } from 'usehooks-ts';
 import { useReconcile } from '../../../Board';
 import { useChess } from '../../PgnBoard';
+import { solitaireBlocksAction } from '../../solitaire/solitaireFrontier';
+import { ShortcutAction } from '../underboard/settings/ShortcutAction';
 import {
     GoToEndButtonBehavior,
     GoToEndButtonBehaviorKey,
@@ -41,27 +43,21 @@ const ControlButtons = () => {
     };
 
     const onNextMove = () => {
-        if (
-            solitaire?.enabled &&
-            !solitaire.complete &&
-            chess?.currentMove() === solitaire.currentMove
-        ) {
+        if (!chess || solitaireBlocksAction(ShortcutAction.NextMove, chess, solitaire)) {
             return;
         }
 
-        const nextMove = chess?.nextMove();
+        const nextMove = chess.nextMove();
         if (nextMove) {
             onClickMove(nextMove);
         }
     };
 
     const onLastMove = () => {
-        if (solitaire?.enabled && !solitaire.complete) {
+        if (!chess || solitaireBlocksAction(ShortcutAction.LastMove, chess, solitaire)) {
             return;
         }
-        if (chess) {
-            onClickMove(chess.lastMove());
-        }
+        onClickMove(chess.lastMove());
     };
 
     return (

--- a/frontend/src/board/pgn/solitaire/solitaireFrontier.test.ts
+++ b/frontend/src/board/pgn/solitaire/solitaireFrontier.test.ts
@@ -1,0 +1,142 @@
+import { Chess } from '@jackstenglein/chess';
+import { describe, expect, it } from 'vitest';
+import { ShortcutAction } from '../boardTools/underboard/settings/ShortcutAction';
+import { isBeyondSolitaireFrontier, solitaireBlocksAction } from './solitaireFrontier';
+
+const PGN = '1. e4 e5 (1... c5 2. Nf3) 2. Nf3 (2. Bc4 Nf6 (2... Nc6 3. d3)) Nc6 3. Bb5 *';
+
+const FORWARD_ACTIONS = [
+    ShortcutAction.NextMove,
+    ShortcutAction.FirstVariation,
+    ShortcutAction.LastMove,
+    ShortcutAction.LastMoveVariation,
+    ShortcutAction.InsertEngineMove,
+];
+
+function load() {
+    const chess = new Chess({ pgn: PGN });
+    chess.seek(null);
+    const [e4, e5, nf3, nc6, bb5] = chess.history();
+    const c5 = e5.variations[0][0];
+    const bc4 = nf3.variations[0][0];
+    const nf6 = bc4.variation[1];
+    const nestedNc6 = nf6.variations[0][0];
+    const nestedD3 = nestedNc6.variation[1];
+    return { chess, e4, e5, nf3, nc6, bb5, c5, bc4, nf6, nestedNc6, nestedD3 };
+}
+
+describe('isBeyondSolitaireFrontier', () => {
+    it('treats a variation as revealed exactly when the mainline move it replaces is', () => {
+        const { chess, e5, nf3, c5, bc4, nf6, nestedNc6, nestedD3 } = load();
+
+        // Frontier at 1...e5: alternatives to e5 are revealed, alternatives to
+        // 2.Nf3 are not, at any depth.
+        expect(isBeyondSolitaireFrontier(chess, e5, c5)).toBe(false);
+        expect(isBeyondSolitaireFrontier(chess, e5, bc4)).toBe(true);
+        expect(isBeyondSolitaireFrontier(chess, e5, nf6)).toBe(true);
+        expect(isBeyondSolitaireFrontier(chess, e5, nestedNc6)).toBe(true);
+        expect(isBeyondSolitaireFrontier(chess, e5, nestedD3)).toBe(true);
+
+        // Frontier at 2.Nf3: the whole 2.Bc4 tree is revealed.
+        expect(isBeyondSolitaireFrontier(chess, nf3, bc4)).toBe(false);
+        expect(isBeyondSolitaireFrontier(chess, nf3, nestedD3)).toBe(false);
+    });
+
+    it('treats everything as unrevealed while the frontier is the start', () => {
+        const { chess, e4, c5 } = load();
+        expect(isBeyondSolitaireFrontier(chess, null, e4)).toBe(true);
+        expect(isBeyondSolitaireFrontier(chess, null, c5)).toBe(true);
+        expect(isBeyondSolitaireFrontier(chess, null, null)).toBe(false);
+    });
+});
+
+describe('solitaireBlocksAction', () => {
+    it('never blocks when solitaire is off or complete', () => {
+        const { chess, nf3 } = load();
+        for (const action of FORWARD_ACTIONS) {
+            expect(solitaireBlocksAction(action, chess, undefined)).toBe(false);
+            expect(
+                solitaireBlocksAction(action, chess, {
+                    enabled: false,
+                    complete: false,
+                    currentMove: null,
+                }),
+            ).toBe(false);
+            expect(
+                solitaireBlocksAction(action, chess, {
+                    enabled: true,
+                    complete: true,
+                    currentMove: nf3,
+                }),
+            ).toBe(false);
+        }
+    });
+
+    it('blocks every forward seek from the start when nothing is revealed', () => {
+        const { chess } = load();
+        const solitaire = { enabled: true, complete: false, currentMove: null };
+        expect(solitaireBlocksAction(ShortcutAction.NextMove, chess, solitaire)).toBe(true);
+        expect(solitaireBlocksAction(ShortcutAction.FirstVariation, chess, solitaire)).toBe(true);
+        expect(solitaireBlocksAction(ShortcutAction.LastMove, chess, solitaire)).toBe(true);
+    });
+
+    it('allows moving forward within the revealed region after stepping back', () => {
+        const { chess, e4, nf3 } = load();
+        const solitaire = { enabled: true, complete: false, currentMove: nf3 };
+
+        chess.seek(null);
+        expect(solitaireBlocksAction(ShortcutAction.NextMove, chess, solitaire)).toBe(false);
+        expect(solitaireBlocksAction(ShortcutAction.LastMove, chess, solitaire)).toBe(true);
+
+        chess.seek(e4);
+        expect(solitaireBlocksAction(ShortcutAction.FirstVariation, chess, solitaire)).toBe(false);
+    });
+
+    it('blocks at the frontier regardless of how the frontier was reached', () => {
+        const { chess, nf3 } = load();
+        const solitaire = { enabled: true, complete: false, currentMove: nf3 };
+        chess.seek(nf3);
+        expect(solitaireBlocksAction(ShortcutAction.NextMove, chess, solitaire)).toBe(true);
+        expect(solitaireBlocksAction(ShortcutAction.FirstVariation, chess, solitaire)).toBe(true);
+        expect(solitaireBlocksAction(ShortcutAction.LastMove, chess, solitaire)).toBe(true);
+        expect(solitaireBlocksAction(ShortcutAction.LastMoveVariation, chess, solitaire)).toBe(
+            true,
+        );
+    });
+
+    it('never blocks navigation inside an already revealed variation', () => {
+        const { chess, c5, nf3 } = load();
+        const solitaire = { enabled: true, complete: false, currentMove: nf3 };
+        chess.seek(c5);
+        expect(solitaireBlocksAction(ShortcutAction.NextMove, chess, solitaire)).toBe(false);
+        expect(solitaireBlocksAction(ShortcutAction.LastMoveVariation, chess, solitaire)).toBe(
+            false,
+        );
+    });
+
+    it('blocks inside a variation of an unrevealed move', () => {
+        const { chess, e5, bc4 } = load();
+        const solitaire = { enabled: true, complete: false, currentMove: e5 };
+        chess.seek(bc4);
+        expect(solitaireBlocksAction(ShortcutAction.NextMove, chess, solitaire)).toBe(true);
+        expect(solitaireBlocksAction(ShortcutAction.FirstVariation, chess, solitaire)).toBe(true);
+        expect(solitaireBlocksAction(ShortcutAction.LastMoveVariation, chess, solitaire)).toBe(
+            true,
+        );
+    });
+
+    it('blocks engine move insertion for the whole run', () => {
+        const { chess, e4, nf3 } = load();
+        const solitaire = { enabled: true, complete: false, currentMove: nf3 };
+        chess.seek(e4);
+        expect(solitaireBlocksAction(ShortcutAction.InsertEngineMove, chess, solitaire)).toBe(true);
+    });
+
+    it('ignores actions that do not seek forward', () => {
+        const { chess, nf3 } = load();
+        const solitaire = { enabled: true, complete: false, currentMove: nf3 };
+        chess.seek(nf3);
+        expect(solitaireBlocksAction(ShortcutAction.PreviousMove, chess, solitaire)).toBe(false);
+        expect(solitaireBlocksAction(ShortcutAction.FirstMove, chess, solitaire)).toBe(false);
+    });
+});

--- a/frontend/src/board/pgn/solitaire/solitaireFrontier.ts
+++ b/frontend/src/board/pgn/solitaire/solitaireFrontier.ts
@@ -1,0 +1,75 @@
+import { Chess, Move } from '@jackstenglein/chess';
+import { ShortcutAction } from '../boardTools/underboard/settings/ShortcutAction';
+import { UseSolitaireChessResponse } from './useSolitaireChess';
+
+export type SolitaireFrontierState = Pick<
+    UseSolitaireChessResponse,
+    'enabled' | 'complete' | 'currentMove'
+>;
+
+/**
+ * The ply that decides whether a move is revealed: its own ply on the mainline,
+ * otherwise the ply of the outermost variation it sits in, which is the ply of
+ * the mainline move that variation replaces.
+ */
+function effectivePly(chess: Chess, move: Move): number {
+    let current = move;
+    while (!chess.isInMainline(current)) {
+        const root = current.variation[0];
+        const parent = root.previous;
+        if (!parent || chess.isInMainline(parent)) {
+            return root.ply;
+        }
+        current = parent;
+    }
+    return current.ply;
+}
+
+/**
+ * Returns true if the given target move lies beyond the solitaire frontier,
+ * meaning it has not been revealed yet. The starting position is never beyond.
+ */
+export function isBeyondSolitaireFrontier(
+    chess: Chess,
+    frontier: Move | null,
+    target: Move | null | undefined,
+): boolean {
+    if (!target) {
+        return false;
+    }
+    return frontier === null || effectivePly(chess, target) > frontier.ply;
+}
+
+/**
+ * Whether the action would seek past the solitaire frontier, or insert a move,
+ * while solitaire is in progress. Compares plies rather than move identity, so
+ * stepping back and forward inside the revealed region stays allowed.
+ */
+export function solitaireBlocksAction(
+    action: ShortcutAction,
+    chess: Chess,
+    solitaire: SolitaireFrontierState | undefined,
+): boolean {
+    if (!solitaire?.enabled || solitaire.complete) {
+        return false;
+    }
+    const frontier = solitaire.currentMove;
+    switch (action) {
+        case ShortcutAction.NextMove:
+        case ShortcutAction.FirstVariation:
+            // FirstVariation falls back to the next mainline move when there are none.
+            return isBeyondSolitaireFrontier(chess, frontier, chess.nextMove());
+        case ShortcutAction.LastMove:
+            return isBeyondSolitaireFrontier(chess, frontier, chess.lastMove());
+        case ShortcutAction.LastMoveVariation: {
+            const move = chess.currentMove();
+            const target = move ? move.variation[move.variation.length - 1] : null;
+            return isBeyondSolitaireFrontier(chess, frontier, target);
+        }
+        case ShortcutAction.InsertEngineMove:
+            // The engine's move is the answer.
+            return true;
+        default:
+            return false;
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes in the shared board stack, one commit each. I hit them while
preparing the Reader.

**Solitaire frontier gate.** The keyboard handler compared the current move
to the frontier by identity, and only for next-move. Any other forward seek,
such as first variation (Shift+ArrowRight) or engine-move insertion (Space),
unlocked plain ArrowRight for the rest of the game. Checkmate puzzles post a
rating from these sessions, so a breach records a result the user did not
earn. One ply-based helper now answers for the keyboard, the wheel and the
control buttons. Might be a bit redundant, but I wanted to include it as it 
simplifies the keyboard handler and makes the board behave consistently.

**Positions load without animation.** chessground animated the initial set
from the default position, so exam problems and custom starts flew their
pieces into place.

**The board re-initializes in the same commit as its props.** It lagged one
render, and PgnBoard's orientation toggle ran in between, so every exam
problem swap showed the old position flipped for a frame, and black-oriented
game pages flipped one frame after first paint.

Known gap, left for its own discussion: Comments and clock-chart clicks on
the game page still seek past the frontier during solitaire, because the
gate sits per input rather than at the seek.

## Related Issues

Groundwork for #2115. No open issue for the three bugs themselves.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* [x] New unit tests (vitest) were added
* [x] New playwright tests were added

Unit tests cover the frontier helper against the real chess engine, and a
PgnBoard test renders the real board over a fake chessground and fails on
the old re-initialization. The Playwright test on the memorize-games page
proves the keyboard path: ArrowRight moves the board in study mode and
nothing moves it past the frontier in test mode. Also run: tsc, eslint, the
full vitest suite, and the memorize-games and games Playwright areas on a
fresh build.

## Demo

Before and after: exam problem swaps, and memorize-games test mode with Shift+ArrowRight.

https://github.com/user-attachments/assets/6339897f-a47f-4e44-a0eb-0909c1d4ace9

https://github.com/user-attachments/assets/7cc978a0-ccf0-45bc-bfb1-56abd08dca2b

https://github.com/user-attachments/assets/b567b892-4aee-4f0c-be7e-8bcee0b4bbc0



