### PR TITLE
fix(frontend): keep the current game on screen while the next one loads

### DIFF
--- a/frontend/playwright/tests/e2e/material/memorizeGames.spec.ts
+++ b/frontend/playwright/tests/e2e/material/memorizeGames.spec.ts
@@ -23,6 +23,30 @@ test.describe('Memorize Games Page', () => {
         await expect(page.getByText('Show Answer')).toBeVisible();
     });
 
+    test('keeps the current game on screen while the next one loads', async ({ page }) => {
+        const items = page.getByTestId('pgn-selector-item');
+        test.skip((await items.count()) < 2, 'needs two games');
+        const firstMove = page.getByTestId('pgn-text-move-button').first();
+        await expect(firstMove).toBeVisible();
+
+        await page.route(/\/public\/game\//, async (route) => {
+            await new Promise((resolve) => setTimeout(resolve, 1500));
+            await route.continue();
+        });
+        const loaded = page.waitForResponse(/\/public\/game\//);
+        await items.nth(1).click();
+        await page.waitForTimeout(300);
+
+        // Mid-load: no spinner, the previous game still on the board.
+        expect(await page.getByRole('progressbar').count()).toBe(0);
+        expect(await page.getByTestId('chessground-board').isVisible()).toBe(true);
+        expect(await firstMove.isVisible()).toBe(true);
+
+        await loaded;
+        await expect(items.nth(1).getByRole('button')).toHaveClass(/Mui-selected/);
+        await expect(page.getByTestId('pgn-text-move-button').first()).toBeVisible();
+    });
+
     test('should switch between games', async ({ page }) => {
         // Click different games from the PGN selector
         const items = page.getByTestId('pgn-selector-item');

--- a/frontend/src/app/[locale]/(scoreboard)/learn/memorizegames/MemorizeGamesPage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/learn/memorizegames/MemorizeGamesPage.tsx
@@ -31,6 +31,8 @@ export function MemorizeGamesPage({ user }: { user: User }) {
     const getRequest = useRequest<Game>();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [mode, setMode] = useState<'study' | 'test'>('study');
+    // Stays on screen while the next game loads; getRequest drops its data.
+    const [game, setGame] = useState<Game>();
     const isFreeTier = useFreeTier();
 
     useEffect(() => {
@@ -61,6 +63,7 @@ export function MemorizeGamesPage({ user }: { user: User }) {
             api.getGame(gameInfo.cohort, gameInfo.id)
                 .then((res) => {
                     getRequest.onSuccess(res.data);
+                    setGame(res.data);
                 })
                 .catch((err) => {
                     getRequest.onFailure(err);
@@ -102,7 +105,7 @@ export function MemorizeGamesPage({ user }: { user: User }) {
 
             <PgnBoard
                 ref={pgnRef}
-                pgn={getRequest.data?.pgn}
+                pgn={game?.pgn}
                 underboardTabs={[
                     {
                         name: 'gameList',

--- a/frontend/src/app/[locale]/(scoreboard)/learn/modelgames/ModelGamesPage.tsx
+++ b/frontend/src/app/[locale]/(scoreboard)/learn/modelgames/ModelGamesPage.tsx
@@ -27,6 +27,8 @@ function AuthModelGamesPage({ user }: { user: User }) {
     const getRequest = useRequest<Game>();
     const [selectedIndex, setSelectedIndex] = useState(0);
     const [cohort, setCohort] = useState(user.dojoCohort);
+    // Stays on screen while the next game loads; getRequest drops its data.
+    const [game, setGame] = useState<Game>();
 
     useEffect(() => {
         if (!listRequest.isSent()) {
@@ -56,6 +58,7 @@ function AuthModelGamesPage({ user }: { user: User }) {
             api.getGame(gameInfo.cohort, gameInfo.id)
                 .then((res) => {
                     getRequest.onSuccess(res.data);
+                    setGame(res.data);
                 })
                 .catch((err) => {
                     getRequest.onFailure(err);
@@ -82,18 +85,18 @@ function AuthModelGamesPage({ user }: { user: User }) {
 
     return (
         <Box sx={{ py: 4, px: 0 }}>
-            {getRequest.isLoading() && (
+            {getRequest.isLoading() && !game && (
                 <Box sx={{ gridArea: 'pgn' }}>
                     <LoadingPage />
                 </Box>
             )}
 
-            {getRequest.data && (
-                <PgnErrorBoundary pgn={getRequest.data.pgn}>
+            {game && (
+                <PgnErrorBoundary pgn={game.pgn}>
                     <PgnBoard
-                        key={getRequest.data.pgn}
-                        pgn={getRequest.data.pgn}
-                        startOrientation={getRequest.data.orientation}
+                        key={game.pgn}
+                        pgn={game.pgn}
+                        startOrientation={game.orientation}
                         disableNullMoves={false}
                         underboardTabs={[
                             {


### PR DESCRIPTION
## Summary

Switching games on the memorize-games and model-games pages blanked
everything below the navbar behind a spinner for about half a second.
Both pages reset the game request on switch, which hands PgnBoard an
undefined PGN until the fetch returns, and PgnBoard's loading overlay
covers the board, the selector and the move list.

Both pages now hold the loaded game in page state that only changes on
success and render the board from it. The previous game stays on screen
until the next one arrives, and the spinner shows only before the first
game loads.

## Related Issues

None open. Same symptom as #2070 for directories (#2095); here the cause
is the loading overlay while the next game is fetched, not a navigation.
Found while recording clips for the board-stack fixes PR.

## Type of change

*   [x] Bug fix (non-breaking change which fixes an issue)

## Testing

* [x] New playwright tests were added

The new Playwright test on the memorize-games page holds the game fetch
for 1.5 seconds, switches game, and 300 ms later checks that no spinner
is on screen and the previous board and move list are still visible.
Then it waits for the fetch and checks the new game is selected. On dev
it fails with one spinner counted; with the fix all six memorize-games
tests pass. tsc, eslint and the full vitest suite also pass.

## Demo

Memorize games, switching between games, before and after.

https://github.com/user-attachments/assets/7b0a5bfd-4e78-4cad-87d6-736e887582dd

https://github.com/user-attachments/assets/205a5949-9121-472f-a158-9be310969d45


